### PR TITLE
Add UDP receive timeout and propagate IOException

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -18,6 +18,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -43,9 +44,12 @@ public class UdpClient {
 
             byte[] buf = new byte[4096];
             DatagramPacket responsePacket = new DatagramPacket(buf, buf.length);
+            socket.setSoTimeout(5000);
             socket.receive(responsePacket);
             UdpResponse response = UdpResponse.fromBytes(responsePacket.getData(), responsePacket.getLength());
             return response.getXml();
+        } catch (SocketTimeoutException e) {
+            throw new IOException("Timeout waiting for UDP response from " + address.getHostAddress() + ":" + port, e);
         } catch (UnsupportedEncodingException e) {
             // should never happen as UTF-8 is always supported
             throw new IOException(e);


### PR DESCRIPTION
## Summary
- ensure Hayward OmniLogic UDP client doesn't hang by setting a 5s timeout
- surface UDP timeouts as IOExceptions for retry/offline handling

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am spotless:apply test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom:[1.0, 2.0))*

------
https://chatgpt.com/codex/tasks/task_e_68c04a5256648323ac3bc0cd3cb59e68