### PR TITLE
feat: centralize hayward command building

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.net.CommandBuilder;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -130,14 +131,9 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
             try {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetHeaterEnable</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"Enabled\" dataType=\"bool\">" + cmdString + "</Parameter>"
-                                + "</Parameters></Request>";
+                        cmdURL = CommandBuilder.buildSetHeaterEnable(HaywardBindingConstants.COMMAND_PARAMETERS,
+                                bridgehandler.account.token, bridgehandler.account.mspSystemID, poolID, systemID,
+                                cmdString);
                         break;
 
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
@@ -149,14 +145,9 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                             }
                         }
 
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetUIHeaterCmd</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"Temp\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                + "</Parameters></Request>";
+                        cmdURL = CommandBuilder.buildSetUIHeaterCmd(HaywardBindingConstants.COMMAND_PARAMETERS,
+                                bridgehandler.account.token, bridgehandler.account.mspSystemID, poolID, systemID,
+                                cmdString);
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/net/CommandBuilder.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/net/CommandBuilder.java
@@ -1,0 +1,60 @@
+package org.openhab.binding.haywardomnilogic.internal.net;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Helper for building XML command strings sent to the Hayward cloud.
+ */
+@NonNullByDefault
+public class CommandBuilder {
+
+    private static final String SET_HEATER_ENABLE = """
+            <Name>SetHeaterEnable</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"PoolID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"HeaterID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Enabled\" dataType=\"bool\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_UI_HEATER_CMD = """
+            <Name>SetUIHeaterCmd</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"PoolID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"HeaterID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Temp\" dataType=\"int\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private CommandBuilder() {
+        // utility class
+    }
+
+    public static String buildSetHeaterEnable(String prefix, String token, int mspSystemID, String poolID,
+            String heaterID, String enabled) {
+        return prefix
+                + String.format(SET_HEATER_ENABLE, token, mspSystemID, poolID, heaterID, enabled)
+                + closingTag(prefix);
+    }
+
+    public static String buildSetUIHeaterCmd(String prefix, String token, int mspSystemID, String poolID,
+            String heaterID, String temp) {
+        return prefix + String.format(SET_UI_HEATER_CMD, token, mspSystemID, poolID, heaterID, temp)
+                + closingTag(prefix);
+    }
+
+    private static String closingTag(String prefix) {
+        if (prefix.contains("<Request>")) {
+            return "</Request>";
+        } else if (prefix.contains("<GetTelemetry>")) {
+            return "</GetTelemetry>";
+        } else {
+            return "";
+        }
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -130,14 +131,9 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
             try {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetHeaterEnable</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"Enabled\" dataType=\"bool\">" + cmdString + "</Parameter>"
-                                + "</Parameters></GetTelemetry>";
+                        cmdURL = CommandBuilder.buildSetHeaterEnable(HaywardBindingConstants.COMMAND_PARAMETERS,
+                                bridgehandler.account.token, bridgehandler.account.mspSystemID, poolID, systemID,
+                                cmdString);
                         break;
 
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
@@ -149,14 +145,9 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                             }
                         }
 
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetUIHeaterCmd</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"Temp\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                + "</Parameters></GetTelemetry>";
+                        cmdURL = CommandBuilder.buildSetUIHeaterCmd(HaywardBindingConstants.COMMAND_PARAMETERS,
+                                bridgehandler.account.token, bridgehandler.account.mspSystemID, poolID, systemID,
+                                cmdString);
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/CommandBuilder.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/CommandBuilder.java
@@ -1,0 +1,60 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.net;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Helper for building XML command strings sent to the Hayward controller.
+ */
+@NonNullByDefault
+public class CommandBuilder {
+
+    private static final String SET_HEATER_ENABLE = """
+            <Name>SetHeaterEnable</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"PoolID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"HeaterID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Enabled\" dataType=\"bool\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_UI_HEATER_CMD = """
+            <Name>SetUIHeaterCmd</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"PoolID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"HeaterID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Temp\" dataType=\"int\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private CommandBuilder() {
+        // utility class
+    }
+
+    public static String buildSetHeaterEnable(String prefix, String token, int mspSystemID, String poolID,
+            String heaterID, String enabled) {
+        return prefix
+                + String.format(SET_HEATER_ENABLE, token, mspSystemID, poolID, heaterID, enabled)
+                + closingTag(prefix);
+    }
+
+    public static String buildSetUIHeaterCmd(String prefix, String token, int mspSystemID, String poolID,
+            String heaterID, String temp) {
+        return prefix + String.format(SET_UI_HEATER_CMD, token, mspSystemID, poolID, heaterID, temp)
+                + closingTag(prefix);
+    }
+
+    private static String closingTag(String prefix) {
+        if (prefix.contains("<Request>")) {
+            return "</Request>";
+        } else if (prefix.contains("<GetTelemetry>")) {
+            return "</GetTelemetry>";
+        } else {
+            return "";
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CommandBuilder utility to assemble Hayward XML requests
- use CommandBuilder in virtual heater handlers

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal,bundles/org.openhab.binding.haywardomnilogic -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c04a5197dc832380c432d974f8faa4