### PR TITLE
Add UDP request/response tests

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequestTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequestTest.java
@@ -1,0 +1,45 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UdpRequest}.
+ */
+@NonNullByDefault
+public class UdpRequestTest {
+
+    private static final String REQUEST_XML = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request xmlns=\"http://nextgen.hayward.com/api\"><Name>RequestTelemetryData</Name></Request>";
+
+    @Test
+    public void toBytesShouldCreateHeaderAndPayload() throws Exception {
+        int messageType = 1004;
+        UdpRequest request = new UdpRequest(messageType, REQUEST_XML);
+
+        byte[] bytes = request.toBytes();
+
+        byte[] xmlBytes = (REQUEST_XML + '\0').getBytes(StandardCharsets.UTF_8);
+        assertEquals(24 + xmlBytes.length, bytes.length);
+
+        String version = new String(bytes, 12, 4, StandardCharsets.US_ASCII);
+        assertEquals("1.22", version);
+
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        assertEquals(messageType, buffer.getInt(16));
+
+        assertEquals(1, bytes[20]);
+        assertEquals(0, bytes[21]);
+        assertEquals(0, bytes[22]);
+        assertEquals(0, bytes[23]);
+
+        String xml = new String(bytes, 24, xmlBytes.length - 1, StandardCharsets.UTF_8);
+        assertEquals(REQUEST_XML, xml);
+        assertEquals(0, bytes[bytes.length - 1]);
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
@@ -1,0 +1,37 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UdpResponse}.
+ */
+@NonNullByDefault
+public class UdpResponseTest {
+
+    private static final String RESPONSE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><STATUS version=\"1.8\"></STATUS>";
+
+    @Test
+    public void fromBytesShouldParseHeaderAndXml() throws Exception {
+        int messageType = 1004;
+        byte[] xmlBytes = (RESPONSE_XML + '\0').getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocate(24 + xmlBytes.length);
+        buffer.putInt(0x01020304);
+        buffer.putLong(0x0102030405060708L);
+        buffer.put("1.22".getBytes(StandardCharsets.US_ASCII));
+        buffer.putInt(messageType);
+        buffer.put((byte) 1);
+        buffer.put(new byte[3]);
+        buffer.put(xmlBytes);
+
+        UdpResponse response = UdpResponse.fromBytes(buffer.array(), buffer.array().length);
+        assertEquals(messageType, response.getMessageType());
+        assertEquals(RESPONSE_XML, response.getXml());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit test for UdpRequest header and XML serialization
- add unit test for UdpResponse header parsing

## Testing
- `mvn -q -pl :org.openhab.binding.haywardomnilogiclocal test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c04a495c388323ae60f260c0846a4f