### PR TITLE
feat(haywardomnilogiclocal): handle multi-block UDP responses

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -13,6 +13,8 @@
 
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
@@ -20,6 +22,9 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.InflaterInputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -36,23 +41,83 @@ public class UdpClient {
         this.port = port;
     }
 
+    private static final int MSG_ACK = 1002;
+    private static final int MSG_LEAD = 1998;
+    private static final int MSG_BLOCK = 1999;
+
     public String send(UdpRequest request) throws IOException {
         byte[] out = request.toBytes();
         try (DatagramSocket socket = new DatagramSocket()) {
             DatagramPacket packet = new DatagramPacket(out, out.length, address, port);
             socket.send(packet);
 
-            byte[] buf = new byte[4096];
-            DatagramPacket responsePacket = new DatagramPacket(buf, buf.length);
-            socket.setSoTimeout(5000);
-            socket.receive(responsePacket);
-            UdpResponse response = UdpResponse.fromBytes(responsePacket.getData(), responsePacket.getLength());
-            return response.getXml();
+            ByteArrayOutputStream blocks = new ByteArrayOutputStream();
+            int expectedBlocks = 0;
+            boolean compressed = false;
+
+            while (true) {
+                byte[] buf = new byte[4096];
+                DatagramPacket responsePacket = new DatagramPacket(buf, buf.length);
+                socket.setSoTimeout(5000);
+                socket.receive(responsePacket);
+
+                byte[] data = new byte[responsePacket.getLength()];
+                System.arraycopy(responsePacket.getData(), 0, data, 0, responsePacket.getLength());
+
+                ByteBuffer buffer = ByteBuffer.wrap(data);
+                int msgId = buffer.getInt();
+                buffer.getLong();
+                buffer.position(16);
+                int msgType = buffer.getInt();
+                buffer.get();
+                int blockCount = Byte.toUnsignedInt(buffer.get());
+                boolean thisCompressed = buffer.get() != 0;
+                buffer.get();
+
+                if (msgType == MSG_LEAD) {
+                    expectedBlocks = blockCount;
+                    compressed = thisCompressed;
+                    sendAck(socket, msgId);
+                } else if (msgType == MSG_BLOCK) {
+                    blocks.write(data, 24, data.length - 24);
+                    expectedBlocks--;
+                    sendAck(socket, msgId);
+                    if (expectedBlocks <= 0) {
+                        byte[] payload = blocks.toByteArray();
+                        if (compressed) {
+                            payload = decompress(payload);
+                        }
+                        return new String(payload, StandardCharsets.UTF_8).trim();
+                    }
+                } else {
+                    return new String(data, 24, data.length - 24, StandardCharsets.UTF_8).trim();
+                }
+            }
         } catch (SocketTimeoutException e) {
             throw new IOException("Timeout waiting for UDP response from " + address.getHostAddress() + ":" + port, e);
         } catch (UnsupportedEncodingException e) {
             // should never happen as UTF-8 is always supported
             throw new IOException(e);
+        }
+    }
+
+    private void sendAck(DatagramSocket socket, int messageId) throws IOException {
+        UdpRequest ack = new UdpRequest(MSG_ACK, "", messageId);
+        byte[] ackBytes = ack.toBytes();
+        DatagramPacket ackPacket = new DatagramPacket(ackBytes, ackBytes.length, address, port);
+        socket.send(ackPacket);
+    }
+
+    private static byte[] decompress(byte[] data) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                InflaterInputStream iis = new InflaterInputStream(bais);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = iis.read(buffer)) != -1) {
+                baos.write(buffer, 0, len);
+            }
+            return baos.toByteArray();
         }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequest.java
@@ -30,10 +30,16 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class UdpRequest {
     private final int messageType;
     private final String xml;
+    private final Integer messageId;
 
     public UdpRequest(int messageType, String xml) {
+        this(messageType, xml, null);
+    }
+
+    public UdpRequest(int messageType, String xml, Integer messageId) {
         this.messageType = messageType;
         this.xml = xml;
+        this.messageId = messageId;
     }
 
     /**
@@ -41,7 +47,7 @@ public class UdpRequest {
      */
     public byte[] toBytes() throws UnsupportedEncodingException {
         Random random = new Random();
-        int msgID = random.nextInt();
+        int msgID = messageId != null ? messageId.intValue() : random.nextInt();
         long timeStamp = System.currentTimeMillis();
         String version = "1.22"; // protocol version
         byte clientType = 1;


### PR DESCRIPTION
## Summary
- Parse MSP_LEADMESSAGE and subsequent MSP_BLOCKMESSAGE packets
- Concatenate payloads and decompress when compressed flag is set
- Send ACK packets after each lead or block message

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c064094dbc8323852c55eded6c5310