### PR TITLE
Remove credentials from Hayward OmniLogic Local binding

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/README.md
@@ -3,7 +3,7 @@
 The Hayward Omnilogic Local binding integrates the OmniLogic pool controller using the local UDP protocol.
 
 Communication occurs directly with the controller on the local network and does not require an Internet connection.
-The controller listens on UDP port 10444 and must be reachable from the openHAB host.
+The local UDP connection requires no authentication, and the controller listens on UDP port 10444 and must be reachable from the openHAB host.
 
 ## Prerequisites
 
@@ -41,8 +41,6 @@ Hayward OmniLogic Controller Parameters:
 | Property             | Default          | Required | Description                                   |
 |----------------------|------------------|----------|-----------------------------------------------|
 | Host Name            | haywardomnilogic | Yes      | Host name or IP address of the controller     |
-| User Name            | None             | Yes      | Your OmniLogic user name (not email address)  |
-| Password             | None             | Yes      | Your OmniLogic user password                  |
 | Telemetry Poll Delay | 3                | Yes      | Telemetry poll delay (2-60 seconds)           |
 | Alarm Poll Delay     | 10               | Yes      | Alarm poll delay (0-120 seconds, 0 disabled)  |
 
@@ -181,6 +179,6 @@ Hayward OmniLogic Controller Parameters:
 
 ## Full Example
 
-After installing the binding, you will need to manually add the Hayward Connection thing and enter your credentials.
+After installing the binding, you will need to manually add the Hayward Connection thing.
 All pool items can be automatically discovered by scanning the bridge.
 Goto the inbox and add the things.

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HaywardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HaywardConfig.java
@@ -23,8 +23,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class HaywardConfig {
     private String endpointUrl = "";
-    private String username = "";
-    private String password = "";
     private int alarmPollTime = 60;
     private int telemetryPollTime = 10;
 
@@ -37,22 +35,6 @@ public class HaywardConfig {
 
     public void setEndpointUrl(String endpointUrl) {
         this.endpointUrl = endpointUrl;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
     }
 
     public int getAlarmPollTime() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
@@ -163,8 +163,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                     return;
                 }
             } catch (HaywardException e) {
-                logger.debug("Unable to send command to Hayward's server {}:{}:{}", bridgehandler.getBridgeConfig().getEndpointUrl(),
-                        bridgehandler.getBridgeConfig().getUsername(), e.getMessage());
+                logger.debug("Unable to send command to Hayward's server {}:{}",
+                        bridgehandler.getBridgeConfig().getEndpointUrl(), e.getMessage());
             }
             this.updateStatus(ThingStatus.ONLINE);
         } else {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/i18n/haywardomnilogic.properties
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/i18n/haywardomnilogic.properties
@@ -23,12 +23,8 @@ thing-type.config.haywardomnilogic.bridge.alarmPollTime.label = Alarm Poll Delay
 thing-type.config.haywardomnilogic.bridge.alarmPollTime.description = How often to request alarm data from Hayward Server. Enter 0 to disable.
 thing-type.config.haywardomnilogic.bridge.endpointUrl.label = Endpoint URL
 thing-type.config.haywardomnilogic.bridge.endpointUrl.description = The URL of the Hayward API Server
-thing-type.config.haywardomnilogic.bridge.password.label = Password
-thing-type.config.haywardomnilogic.bridge.password.description = The password to connect to the server.
 thing-type.config.haywardomnilogic.bridge.telemetryPollTime.label = Telemetry Poll Delay
 thing-type.config.haywardomnilogic.bridge.telemetryPollTime.description = How often to request telemetry data from Hayward Server
-thing-type.config.haywardomnilogic.bridge.username.label = User Name
-thing-type.config.haywardomnilogic.bridge.username.description = The username to connect to the server.
 
 # channel types
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/bridge.xml
@@ -16,15 +16,6 @@
 				<default>https://www.haywardomnilogic.com/HAAPI/HomeAutomation/API.ashx</default>
 				<description>The URL of the Hayward API Server</description>
 			</parameter>
-			<parameter name="username" type="text" required="true">
-				<label>User Name</label>
-				<description>The username to connect to the server.</description>
-			</parameter>
-			<parameter name="password" type="text" required="true">
-				<context>password</context>
-				<label>Password</label>
-				<description>The password to connect to the server.</description>
-			</parameter>
 			<parameter name="telemetryPollTime" type="integer" min="2" max="60" unit="s" required="true">
 				<label>Telemetry Poll Delay</label>
 				<default>3</default>


### PR DESCRIPTION
## Summary
- drop username and password fields from HaywardConfig and handler logic
- remove credential parameters from bridge and i18n descriptors
- document that the local UDP connection needs no authentication

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c064132a3883238e13718e78d7d8fd