### PR TITLE
fix: update haywardomnilogiclocal thing descriptor schema

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/backyard.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/backyard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/bow.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/bow.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="haywardomnilogiclocal"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="bow" listed="false">
 		<supported-bridge-type-refs>

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/bridge.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/bridge.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="haywardomnilogiclocal"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<!-- The bridge to communicate with Hayward's server -->
 	<bridge-type id="bridge">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/chlorinator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/chlorinator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/colorlogic.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/colorlogic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/filter.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/heater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/heater.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/pump.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/pump.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/relay.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/relay.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="haywardomnilogic"
+<thing:thing-descriptions bindingId="haywardomnilogiclocal"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/virtualHeater.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/resources/OH-INF/thing/virtualHeater.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="haywardomnilogiclocal"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="virtualHeater" listed="false">
 		<supported-bridge-type-refs>


### PR DESCRIPTION
## Summary
- ensure all haywardomnilogiclocal thing descriptors use current schema snippet

## Testing
- `mvn -q clean verify` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom*[1.0, 2.0) )*

------
https://chatgpt.com/codex/tasks/task_e_68c070d819f88323bc5ab5155b5fe71c