### PR TITLE
hayward: encapsulate GetTelemetry fields

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/GetTelemetry.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/GetTelemetry.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogiclocal.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ *
+ * @author Matt Myers - Initial contribution
+ */
+@NonNullByDefault
+public class GetTelemetry {
+
+    private final String xmlns;
+    private final String name;
+
+    public GetTelemetry() {
+        this.xmlns = "http://nextgen.hayward.com/api";
+        this.name = "RequestTelemetryData";
+    }
+
+    public String getXmlns() {
+        return xmlns;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
## Summary
- encapsulate GetTelemetry fields and provide accessors

## Testing
- `mvn -q -pl :org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c070fc259c8323868dcd6dfe57d866