### PR TITLE
Add protocol ParameterValue and helpers

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
@@ -16,7 +16,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.handler.HaywardBridgeHandler;
+import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
@@ -137,5 +139,20 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
             }
         }
         return channelStates;
+    }
+
+    protected void updateIfPresent(Map<String, ParameterValue> values, String key, String channelID) {
+        @Nullable ParameterValue parameter = values.get(key);
+        if (parameter != null && parameter.value() != null) {
+            updateData(channelID, parameter.value());
+        }
+    }
+
+    protected void putIfPresent(Map<String, ParameterValue> values, String key, Map<String, String> properties,
+            String propertyName) {
+        @Nullable ParameterValue parameter = values.get(key);
+        if (parameter != null && parameter.value() != null) {
+            properties.put(propertyName, parameter.value());
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/protocol/ParameterValue.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/protocol/ParameterValue.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogiclocal.internal.protocol;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Represents a configuration value returned by the Hayward OmniLogic
+ * protocol.
+ */
+@NonNullByDefault
+public record ParameterValue(@Nullable String value) {
+}
+


### PR DESCRIPTION
## Summary
- add protocol package with ParameterValue record for configuration values
- use ParameterValue in HaywardThingHandler with helper update methods

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am compile` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0875f97348323a69d27136891a33a