### PR TITLE
hayward: provide default getTelemetry implementation

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
@@ -58,7 +58,8 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
     public void handleCommand(ChannelUID channelUID, Command command) {
     }
 
-    public abstract void getTelemetry(String xmlResponse) throws HaywardException;
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+    }
 
     public void setStateDescriptions() throws HaywardException {
     }


### PR DESCRIPTION
## Summary
- give `HaywardThingHandler` a default no-op `getTelemetry` implementation so subclasses don't need to override it

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0907202188323852f8bd30186bcc0