### PR TITLE
fix: handle nullable parameters in HaywardThingHandler

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
@@ -143,16 +143,18 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
 
     protected void updateIfPresent(Map<String, ParameterValue> values, String key, String channelID) {
         @Nullable ParameterValue parameter = values.get(key);
-        if (parameter != null && parameter.value() != null) {
-            updateData(channelID, parameter.value());
+        @Nullable String value = parameter != null ? parameter.value() : null;
+        if (value != null) {
+            updateData(channelID, value);
         }
     }
 
     protected void putIfPresent(Map<String, ParameterValue> values, String key, Map<String, String> properties,
             String propertyName) {
         @Nullable ParameterValue parameter = values.get(key);
-        if (parameter != null && parameter.value() != null) {
-            properties.put(propertyName, parameter.value());
+        @Nullable String value = parameter != null ? parameter.value() : null;
+        if (value != null) {
+            properties.put(propertyName, value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid potential null dereferences in `updateIfPresent` and `putIfPresent`

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am compile` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0907e849483239371397e995ca24d