### PR TITLE
[haywardomnilogiclocal] Annotate nullable messageId

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequest.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Represents a UDP request to the OmniLogic controller.
@@ -30,13 +31,13 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class UdpRequest {
     private final int messageType;
     private final String xml;
-    private final Integer messageId;
+    private final @Nullable Integer messageId;
 
     public UdpRequest(int messageType, String xml) {
         this(messageType, xml, null);
     }
 
-    public UdpRequest(int messageType, String xml, Integer messageId) {
+    public UdpRequest(int messageType, String xml, @Nullable Integer messageId) {
         this.messageType = messageType;
         this.xml = xml;
         this.messageId = messageId;


### PR DESCRIPTION
## Summary
- mark UdpRequest messageId field and parameter as nullable and import the annotation

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c090a095e88323bcff8154cc482323