### PR TITLE
feat(haywardomnilogiclocal): support MSP config via UDP

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
@@ -54,7 +54,7 @@ public class HaywardDiscoveryService extends AbstractThingHandlerDiscoveryServic
     @Override
     protected void startScan() {
         try {
-            String xmlResults = thingHandler.getMspConfig();
+            String xmlResults = thingHandler.getMspConfigV2();
             mspConfigDiscovery(xmlResults);
         } catch (HaywardException e) {
             logger.warn("Exception during discovery scan: {}", e.getMessage());

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
@@ -174,6 +174,31 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     }
 
 
+    @Deprecated
+    public synchronized String getMspConfig() throws HaywardException, InterruptedException {
+        return getMspConfigV2();
+    }
+
+    public synchronized String getMspConfigV2() throws HaywardException, InterruptedException {
+        String urlParameters = "<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?><Request><Name>GetMspConfig</Name><Parameters/></Request>";
+
+        String xmlResponse = udpXmlResponse(urlParameters, MSG_TYPE_REQUEST);
+
+        if (xmlResponse.isEmpty()) {
+            logger.debug("Hayward Connection thing: MSP config XML response was null");
+            return "Fail";
+        }
+
+        List<String> configs = evaluateXPath("//Parameter[@name='MspConfig']/text()", xmlResponse);
+        if (configs.isEmpty()) {
+            logger.debug("Hayward Connection thing: MSP config XML response: {}", xmlResponse);
+            return "Fail";
+        }
+
+        return configs.get(0);
+    }
+
+
     public synchronized boolean getTelemetryData() throws HaywardException {
         String urlParameters = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request><Name>GetTelemetryData</Name><Parameters/></Request>";
 


### PR DESCRIPTION
## Summary
- Add UDP-based MSP configuration request with evaluation logic
- Use new MSP configuration method during device discovery

## Testing
- `mvn -pl :org.openhab.binding.haywardomnilogiclocal -am -q verify` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0908aac288323bf70d8aca571169d