### PR TITLE
feat(hayward): add command builder

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogic/README.md
+++ b/bundles/org.openhab.binding.haywardomnilogic/README.md
@@ -4,6 +4,21 @@ The Hayward Omnilogic binding integrates the Omnilogic pool controller using the
 
 The Hayward Omnilogic API interacts with Hayward's cloud server requiring a connection with the Internet for sending and receiving information.
 
+## Command Builder
+
+The binding constructs XML requests through a `HaywardCommandBuilder` that exposes a
+`HaywardCommand` enum for the supported API operations:
+
+* `SetUIEquipmentCmd`
+* `SetStandAloneLightShow`
+* `SetStandAloneLightShowV2`
+* `SetCHLORParams`
+* `SetHeaterEnable`
+* `SetUIHeaterCmd`
+
+The builder provides fluent methods to supply the authentication token, system and pool identifiers,
+equipment identifiers and command specific parameters before producing the final XML payload.
+
 ## Supported Things
 
 The table below lists the Hayward OmniLogic binding thing types:

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/api/HaywardCommandBuilder.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/api/HaywardCommandBuilder.java
@@ -1,0 +1,124 @@
+package org.openhab.binding.haywardomnilogic.internal.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+
+/**
+ * Builder for constructing Hayward OmniLogic command XML payloads.
+ *
+ * @author ChatGPT
+ */
+@NonNullByDefault
+public class HaywardCommandBuilder {
+
+    /**
+     * Enumeration of supported Hayward OmniLogic API commands.
+     */
+    public enum HaywardCommand {
+        SET_UI_EQUIPMENT_CMD("SetUIEquipmentCmd"),
+        SET_STAND_ALONE_LIGHT_SHOW("SetStandAloneLightShow"),
+        SET_STAND_ALONE_LIGHT_SHOW_V2("SetStandAloneLightShowV2"),
+        SET_CHLOR_PARAMS("SetCHLORParams"),
+        SET_HEATER_ENABLE("SetHeaterEnable"),
+        SET_UI_HEATER_CMD("SetUIHeaterCmd");
+
+        private final String apiName;
+
+        HaywardCommand(String apiName) {
+            this.apiName = apiName;
+        }
+
+        public String getApiName() {
+            return apiName;
+        }
+    }
+
+    private record Parameter(String name, String dataType, String value, String alias, String unit) {
+    }
+
+    private final HaywardCommand command;
+    private final List<Parameter> parameters = new ArrayList<>();
+    private boolean includeSchedule = false;
+
+    private HaywardCommandBuilder(HaywardCommand command) {
+        this.command = command;
+    }
+
+    public static HaywardCommandBuilder command(HaywardCommand command) {
+        return new HaywardCommandBuilder(command);
+    }
+
+    public HaywardCommandBuilder withToken(String token) {
+        return withParameter("Token", "String", token);
+    }
+
+    public HaywardCommandBuilder withMspSystemId(String id) {
+        return withParameter("MspSystemID", "int", id);
+    }
+
+    public HaywardCommandBuilder withPoolId(String id) {
+        return withParameter("PoolID", "int", id);
+    }
+
+    public HaywardCommandBuilder withEquipmentId(String id) {
+        return withParameter("EquipmentID", "int", id);
+    }
+
+    public HaywardCommandBuilder withLightId(String id) {
+        return withParameter("LightID", "int", id);
+    }
+
+    public HaywardCommandBuilder withHeaterId(String id) {
+        return withParameter("HeaterID", "int", id);
+    }
+
+    public HaywardCommandBuilder withChlorId(String id) {
+        return withParameter("ChlorID", "int", id, "EquipmentID", null);
+    }
+
+    public HaywardCommandBuilder withParameter(String name, String dataType, String value) {
+        parameters.add(new Parameter(name, dataType, value, null, null));
+        return this;
+    }
+
+    public HaywardCommandBuilder withParameter(String name, String dataType, String value, String alias) {
+        parameters.add(new Parameter(name, dataType, value, alias, null));
+        return this;
+    }
+
+    public HaywardCommandBuilder withParameter(String name, String dataType, String value, String alias, String unit) {
+        parameters.add(new Parameter(name, dataType, value, alias, unit));
+        return this;
+    }
+
+    public HaywardCommandBuilder includeSchedule() {
+        this.includeSchedule = true;
+        return this;
+    }
+
+    public String build() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(HaywardBindingConstants.COMMAND_PARAMETERS);
+        sb.append("<Name>").append(command.getApiName()).append("</Name><Parameters>");
+        for (Parameter p : parameters) {
+            sb.append("<Parameter name=\"").append(p.name)
+                    .append("\" dataType=\"").append(p.dataType).append("\"");
+            if (p.alias != null) {
+                sb.append(" alias=\"").append(p.alias).append("\"");
+            }
+            if (p.unit != null) {
+                sb.append(" unit=\"").append(p.unit).append("\"");
+            }
+            sb.append(">").append(p.value).append("</Parameter>");
+        }
+        if (includeSchedule) {
+            sb.append(HaywardBindingConstants.COMMAND_SCHEDULE);
+        }
+        sb.append("</Parameters></Request>");
+        return sb.toString();
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardChlorinatorHandler.java
@@ -21,6 +21,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -145,22 +147,17 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
                         return;
                 }
 
-                String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetCHLORParams</Name><Parameters>"
-                        + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                        + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                        + bridgehandler.account.mspSystemID + "</Parameter>"
-                        + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                        + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">" + systemID
-                        + "</Parameter>" + "<Parameter name=\"CfgState\" dataType=\"byte\" alias=\"Data1\">"
-                        + chlorCfgState + "</Parameter>"
-                        + "<Parameter name=\"OpMode\" dataType=\"byte\" alias=\"Data2\">1</Parameter>"
-                        + "<Parameter name=\"BOWType\" dataType=\"byte\" alias=\"Data3\">1</Parameter>"
-                        + "<Parameter name=\"CellType\" dataType=\"byte\" alias=\"Data4\">4</Parameter>"
-                        + "<Parameter name=\"TimedPercent\" dataType=\"byte\" alias=\"Data5\">" + chlorTimedPercent
-                        + "</Parameter>"
-                        + "<Parameter name=\"SCTimeout\" dataType=\"byte\" unit=\"hour\" alias=\"Data6\">24</Parameter>"
-                        + "<Parameter name=\"ORPTimout\" dataType=\"byte\" unit=\"hour\" alias=\"Data7\">24</Parameter>"
-                        + "</Parameters></Request>";
+                String cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_CHLOR_PARAMS)
+                        .withToken(bridgehandler.account.token)
+                        .withMspSystemId(bridgehandler.account.mspSystemID)
+                        .withPoolId(poolID).withChlorId(systemID)
+                        .withParameter("CfgState", "byte", chlorCfgState, "Data1")
+                        .withParameter("OpMode", "byte", "1", "Data2")
+                        .withParameter("BOWType", "byte", "1", "Data3")
+                        .withParameter("CellType", "byte", "4", "Data4")
+                        .withParameter("TimedPercent", "byte", chlorTimedPercent, "Data5")
+                        .withParameter("SCTimeout", "byte", "24", "Data6", "hour")
+                        .withParameter("ORPTimout", "byte", "24", "Data7", "hour").build();
 
                 // *****Send Command to Hayward server
                 String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardColorLogicHandler.java
@@ -21,6 +21,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -239,50 +241,35 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                             } else {
                                 cmdString = "0";
                             }
-                            cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                    + "<Name>SetUIEquipmentCmd</Name><Parameters>"
-                                    + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                    + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                    + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                    + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                    + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                    + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                            cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_UI_EQUIPMENT_CMD)
+                                    .withToken(bridgehandler.account.token)
+                                    .withMspSystemId(bridgehandler.account.mspSystemID)
+                                    .withPoolId(poolID).withEquipmentId(systemID)
+                                    .withParameter("IsOn", "int", cmdString).includeSchedule().build();
                             break;
                         case HaywardBindingConstants.CHANNEL_COLORLOGIC_CURRENTSHOW:
                             String lightType = getThing().getProperties()
                                     .get(HaywardBindingConstants.PROPERTY_COLORLOGIC_TYPE);
                             if (lightType != null) {
                                 if (!"COLOR_LOGIC_UCL_V2".equals(lightType)) {
-                                    cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                            + "<Name>SetStandAloneLightShow</Name><Parameters>"
-                                            + "<Parameter name=\"Token\" dataType=\"String\">"
-                                            + bridgehandler.account.token + "</Parameter>"
-                                            + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                            + bridgehandler.account.mspSystemID + "</Parameter>"
-                                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                            + "<Parameter name=\"LightID\" dataType=\"int\">" + systemID
-                                            + "</Parameter>" + "<Parameter name=\"Show\" dataType=\"int\">" + cmdString
-                                            + "</Parameter>" + HaywardBindingConstants.COMMAND_SCHEDULE
-                                            + "</Parameters></Request>";
+                                    cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_STAND_ALONE_LIGHT_SHOW)
+                                            .withToken(bridgehandler.account.token)
+                                            .withMspSystemId(bridgehandler.account.mspSystemID)
+                                            .withPoolId(poolID).withLightId(systemID)
+                                            .withParameter("Show", "int", cmdString).includeSchedule().build();
                                 } else {
                                     brightness = channelStates
                                             .get(HaywardBindingConstants.CHANNEL_COLORLOGIC_BRIGHTNESS).toString();
                                     speed = channelStates.get(HaywardBindingConstants.CHANNEL_COLORLOGIC_SPEED)
                                             .toString();
-                                    cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                            + "<Name>SetStandAloneLightShowV2</Name><Parameters>"
-                                            + "<Parameter name=\"Token\" dataType=\"String\">"
-                                            + bridgehandler.account.token + "</Parameter>"
-                                            + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                            + bridgehandler.account.mspSystemID + "</Parameter>"
-                                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                            + "<Parameter name=\"LightID\" dataType=\"int\">" + systemID
-                                            + "</Parameter>" + "<Parameter name=\"Show\" dataType=\"int\">" + cmdString
-                                            + "</Parameter>" + "<Parameter name=\"Speed\" dataType=\"byte\">" + speed
-                                            + "</Parameter>" + "<Parameter name=\"Brightness\" dataType=\"byte\">"
-                                            + brightness + "</Parameter>" + HaywardBindingConstants.COMMAND_SCHEDULE
-                                            + "</Parameters></Request>";
+                                    cmdURL = HaywardCommandBuilder.command(
+                                            HaywardCommand.SET_STAND_ALONE_LIGHT_SHOW_V2)
+                                            .withToken(bridgehandler.account.token)
+                                            .withMspSystemId(bridgehandler.account.mspSystemID)
+                                            .withPoolId(poolID).withLightId(systemID)
+                                            .withParameter("Show", "int", cmdString)
+                                            .withParameter("Speed", "byte", speed)
+                                            .withParameter("Brightness", "byte", brightness).includeSchedule().build();
 
                                 }
                             }
@@ -293,17 +280,13 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                             if (Integer.parseInt(cmdString) > 4) {
                                 cmdString = "4";
                             }
-                            cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                    + "<Name>SetStandAloneLightShowV2</Name><Parameters>"
-                                    + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                    + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                    + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                    + "<Parameter name=\"LightID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                    + "<Parameter name=\"Show\" dataType=\"int\">" + show + "</Parameter>"
-                                    + "<Parameter name=\"Speed\" dataType=\"byte\">" + speed + "</Parameter>"
-                                    + "<Parameter name=\"Brightness\" dataType=\"byte\">" + cmdString + "</Parameter>"
-                                    + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                            cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_STAND_ALONE_LIGHT_SHOW_V2)
+                                    .withToken(bridgehandler.account.token)
+                                    .withMspSystemId(bridgehandler.account.mspSystemID)
+                                    .withPoolId(poolID).withLightId(systemID)
+                                    .withParameter("Show", "int", show)
+                                    .withParameter("Speed", "byte", speed)
+                                    .withParameter("Brightness", "byte", cmdString).includeSchedule().build();
                             break;
                         case HaywardBindingConstants.CHANNEL_COLORLOGIC_SPEED:
                             brightness = channelStates.get(HaywardBindingConstants.CHANNEL_COLORLOGIC_BRIGHTNESS)
@@ -312,17 +295,13 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
                             if (Integer.parseInt(cmdString) > 8) {
                                 cmdString = "8";
                             }
-                            cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                    + "<Name>SetStandAloneLightShowV2</Name><Parameters>"
-                                    + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                    + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                    + bridgehandler.account.mspSystemID + "</Parameter>"
-                                    + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                    + "<Parameter name=\"LightID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                    + "<Parameter name=\"Show\" dataType=\"int\">" + show + "</Parameter>"
-                                    + "<Parameter name=\"Speed\" dataType=\"byte\">" + cmdString + "</Parameter>"
-                                    + "<Parameter name=\"Brightness\" dataType=\"byte\">" + brightness + "</Parameter>"
-                                    + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                            cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_STAND_ALONE_LIGHT_SHOW_V2)
+                                    .withToken(bridgehandler.account.token)
+                                    .withMspSystemId(bridgehandler.account.mspSystemID)
+                                    .withPoolId(poolID).withLightId(systemID)
+                                    .withParameter("Show", "int", show)
+                                    .withParameter("Speed", "byte", cmdString)
+                                    .withParameter("Brightness", "byte", brightness).includeSchedule().build();
                             break;
                         default:
                             logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardFilterHandler.java
@@ -22,6 +22,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -232,15 +234,11 @@ public class HaywardFilterHandler extends HaywardThingHandler {
                             return;
                     }
 
-                    String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                            + "<Name>SetUIEquipmentCmd</Name><Parameters>"
-                            + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                            + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                            + bridgehandler.account.mspSystemID + "</Parameter>"
-                            + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                            + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
-                            + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
-                            + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                    String cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_UI_EQUIPMENT_CMD)
+                            .withToken(bridgehandler.account.token)
+                            .withMspSystemId(bridgehandler.account.mspSystemID)
+                            .withPoolId(poolID).withEquipmentId(systemID)
+                            .withParameter("IsOn", "int", cmdString).includeSchedule().build();
 
                     // *****Send Command to Hayward server
                     String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardPumpHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardPumpHandler.java
@@ -22,6 +22,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -224,15 +226,13 @@ public class HaywardPumpHandler extends HaywardThingHandler {
                         return;
                 }
 
-                String cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                        + "<Name>SetUIEquipmentCmd</Name><Parameters>"
-                        + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                        + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                        + bridgehandler.account.mspSystemID + "</Parameter>"
-                        + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                        + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
-                        + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
-                        + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                String cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_UI_EQUIPMENT_CMD)
+                        .withToken(bridgehandler.account.token)
+                        .withMspSystemId(bridgehandler.account.mspSystemID)
+                        .withPoolId(poolID)
+                        .withEquipmentId(systemID)
+                        .withParameter("IsOn", "int", cmdString)
+                        .includeSchedule().build();
 
                 // *****Send Command to Hayward server
                 String xmlResponse = bridgehandler.httpXmlResponse(cmdURL);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardRelayHandler.java
@@ -19,6 +19,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -79,15 +81,11 @@ public class HaywardRelayHandler extends HaywardThingHandler {
             try {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_RELAY_STATE:
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS
-                                + "<Name>SetUIEquipmentCmd</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"EquipmentID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"IsOn\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+                        cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_UI_EQUIPMENT_CMD)
+                                .withToken(bridgehandler.account.token)
+                                .withMspSystemId(bridgehandler.account.mspSystemID)
+                                .withPoolId(poolID).withEquipmentId(systemID)
+                                .withParameter("IsOn", "int", cmdString).includeSchedule().build();
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -20,6 +20,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogic.internal.HaywardException;
 import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -130,14 +132,11 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
             try {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetHeaterEnable</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"Enabled\" dataType=\"bool\">" + cmdString + "</Parameter>"
-                                + "</Parameters></Request>";
+                        cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_HEATER_ENABLE)
+                                .withToken(bridgehandler.account.token)
+                                .withMspSystemId(bridgehandler.account.mspSystemID)
+                                .withPoolId(poolID).withHeaterId(systemID)
+                                .withParameter("Enabled", "bool", cmdString).build();
                         break;
 
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
@@ -149,14 +148,11 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                             }
                         }
 
-                        cmdURL = HaywardBindingConstants.COMMAND_PARAMETERS + "<Name>SetUIHeaterCmd</Name><Parameters>"
-                                + "<Parameter name=\"Token\" dataType=\"String\">" + bridgehandler.account.token
-                                + "</Parameter>" + "<Parameter name=\"MspSystemID\" dataType=\"int\">"
-                                + bridgehandler.account.mspSystemID + "</Parameter>"
-                                + "<Parameter name=\"PoolID\" dataType=\"int\">" + poolID + "</Parameter>"
-                                + "<Parameter name=\"HeaterID\" dataType=\"int\">" + systemID + "</Parameter>"
-                                + "<Parameter name=\"Temp\" dataType=\"int\">" + cmdString + "</Parameter>"
-                                + "</Parameters></Request>";
+                        cmdURL = HaywardCommandBuilder.command(HaywardCommand.SET_UI_HEATER_CMD)
+                                .withToken(bridgehandler.account.token)
+                                .withMspSystemId(bridgehandler.account.mspSystemID)
+                                .withPoolId(poolID).withHeaterId(systemID)
+                                .withParameter("Temp", "int", cmdString).build();
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/test/java/org/openhab/binding/haywardomnilogic/internal/api/HaywardCommandBuilderTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/test/java/org/openhab/binding/haywardomnilogic/internal/api/HaywardCommandBuilderTest.java
@@ -1,0 +1,138 @@
+package org.openhab.binding.haywardomnilogic.internal.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.api.HaywardCommandBuilder.HaywardCommand;
+
+/**
+ * Tests for {@link HaywardCommandBuilder}.
+ */
+public class HaywardCommandBuilderTest {
+
+    @Test
+    public void testSetUiEquipmentCmd() {
+        String expected = HaywardBindingConstants.COMMAND_PARAMETERS
+                + "<Name>SetUIEquipmentCmd</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">t</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">1</Parameter>"
+                + "<Parameter name=\"PoolID\" dataType=\"int\">2</Parameter>"
+                + "<Parameter name=\"EquipmentID\" dataType=\"int\">3</Parameter>"
+                + "<Parameter name=\"IsOn\" dataType=\"int\">4</Parameter>"
+                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+
+        String actual = HaywardCommandBuilder.command(HaywardCommand.SET_UI_EQUIPMENT_CMD)
+                .withToken("t").withMspSystemId("1").withPoolId("2").withEquipmentId("3")
+                .withParameter("IsOn", "int", "4").includeSchedule().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetStandAloneLightShow() {
+        String expected = HaywardBindingConstants.COMMAND_PARAMETERS
+                + "<Name>SetStandAloneLightShow</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">t</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">1</Parameter>"
+                + "<Parameter name=\"PoolID\" dataType=\"int\">2</Parameter>"
+                + "<Parameter name=\"LightID\" dataType=\"int\">3</Parameter>"
+                + "<Parameter name=\"Show\" dataType=\"int\">4</Parameter>"
+                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+
+        String actual = HaywardCommandBuilder.command(HaywardCommand.SET_STAND_ALONE_LIGHT_SHOW)
+                .withToken("t").withMspSystemId("1").withPoolId("2").withLightId("3")
+                .withParameter("Show", "int", "4").includeSchedule().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetStandAloneLightShowV2() {
+        String expected = HaywardBindingConstants.COMMAND_PARAMETERS
+                + "<Name>SetStandAloneLightShowV2</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">t</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">1</Parameter>"
+                + "<Parameter name=\"PoolID\" dataType=\"int\">2</Parameter>"
+                + "<Parameter name=\"LightID\" dataType=\"int\">3</Parameter>"
+                + "<Parameter name=\"Show\" dataType=\"int\">4</Parameter>"
+                + "<Parameter name=\"Speed\" dataType=\"byte\">5</Parameter>"
+                + "<Parameter name=\"Brightness\" dataType=\"byte\">6</Parameter>"
+                + HaywardBindingConstants.COMMAND_SCHEDULE + "</Parameters></Request>";
+
+        String actual = HaywardCommandBuilder.command(HaywardCommand.SET_STAND_ALONE_LIGHT_SHOW_V2)
+                .withToken("t").withMspSystemId("1").withPoolId("2").withLightId("3")
+                .withParameter("Show", "int", "4").withParameter("Speed", "byte", "5")
+                .withParameter("Brightness", "byte", "6").includeSchedule().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetChlorParams() {
+        String expected = HaywardBindingConstants.COMMAND_PARAMETERS
+                + "<Name>SetCHLORParams</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">t</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">1</Parameter>"
+                + "<Parameter name=\"PoolID\" dataType=\"int\">2</Parameter>"
+                + "<Parameter name=\"ChlorID\" dataType=\"int\" alias=\"EquipmentID\">3</Parameter>"
+                + "<Parameter name=\"CfgState\" dataType=\"byte\" alias=\"Data1\">4</Parameter>"
+                + "<Parameter name=\"OpMode\" dataType=\"byte\" alias=\"Data2\">1</Parameter>"
+                + "<Parameter name=\"BOWType\" dataType=\"byte\" alias=\"Data3\">1</Parameter>"
+                + "<Parameter name=\"CellType\" dataType=\"byte\" alias=\"Data4\">4</Parameter>"
+                + "<Parameter name=\"TimedPercent\" dataType=\"byte\" alias=\"Data5\">5</Parameter>"
+                + "<Parameter name=\"SCTimeout\" dataType=\"byte\" unit=\"hour\" alias=\"Data6\">24</Parameter>"
+                + "<Parameter name=\"ORPTimout\" dataType=\"byte\" unit=\"hour\" alias=\"Data7\">24</Parameter>"
+                + "</Parameters></Request>";
+
+        String actual = HaywardCommandBuilder.command(HaywardCommand.SET_CHLOR_PARAMS)
+                .withToken("t").withMspSystemId("1").withPoolId("2").withChlorId("3")
+                .withParameter("CfgState", "byte", "4", "Data1")
+                .withParameter("OpMode", "byte", "1", "Data2")
+                .withParameter("BOWType", "byte", "1", "Data3")
+                .withParameter("CellType", "byte", "4", "Data4")
+                .withParameter("TimedPercent", "byte", "5", "Data5")
+                .withParameter("SCTimeout", "byte", "24", "Data6", "hour")
+                .withParameter("ORPTimout", "byte", "24", "Data7", "hour")
+                .build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetHeaterEnable() {
+        String expected = HaywardBindingConstants.COMMAND_PARAMETERS
+                + "<Name>SetHeaterEnable</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">t</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">1</Parameter>"
+                + "<Parameter name=\"PoolID\" dataType=\"int\">2</Parameter>"
+                + "<Parameter name=\"HeaterID\" dataType=\"int\">3</Parameter>"
+                + "<Parameter name=\"Enabled\" dataType=\"bool\">true</Parameter>"
+                + "</Parameters></Request>";
+
+        String actual = HaywardCommandBuilder.command(HaywardCommand.SET_HEATER_ENABLE)
+                .withToken("t").withMspSystemId("1").withPoolId("2").withHeaterId("3")
+                .withParameter("Enabled", "bool", "true").build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSetUiHeaterCmd() {
+        String expected = HaywardBindingConstants.COMMAND_PARAMETERS
+                + "<Name>SetUIHeaterCmd</Name><Parameters>"
+                + "<Parameter name=\"Token\" dataType=\"String\">t</Parameter>"
+                + "<Parameter name=\"MspSystemID\" dataType=\"int\">1</Parameter>"
+                + "<Parameter name=\"PoolID\" dataType=\"int\">2</Parameter>"
+                + "<Parameter name=\"HeaterID\" dataType=\"int\">3</Parameter>"
+                + "<Parameter name=\"Temp\" dataType=\"int\">40</Parameter>"
+                + "</Parameters></Request>";
+
+        String actual = HaywardCommandBuilder.command(HaywardCommand.SET_UI_HEATER_CMD)
+                .withToken("t").withMspSystemId("1").withPoolId("2").withHeaterId("3")
+                .withParameter("Temp", "int", "40").build();
+
+        assertEquals(expected, actual);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HaywardCommandBuilder with enum for OmniLogic API commands
- refactor handlers to use fluent builder instead of manual XML
- document supported commands in README

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogic -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0937138f88323874a7ee3234156a7