### PR TITLE
feat(haywardomnilogiclocal): add command builders for equipment

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardChlorinatorHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -18,17 +19,21 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         String sysId = getThing().getProperties().get("systemID");
-        if (sysId == null) {
+        Bridge bridge = getBridge();
+        if (sysId == null || bridge == null || !(bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler)) {
             return;
         }
 
         switch (channelUID.getId()) {
             case "chlorEnable":
-                sendUdpCommand(CommandBuilder.setEquipmentEnable(sysId, "ON".equalsIgnoreCase(command.toString())));
+                sendUdpCommand(CommandBuilder.setEquipmentEnable(bridgehandler.getAccount().getToken(),
+                        bridgehandler.getAccount().getMspSystemID(), sysId,
+                        "ON".equalsIgnoreCase(command.toString())));
                 break;
             case "chlorSaltOutput":
                 int val = ((Number) command).intValue();
-                sendUdpCommand(CommandBuilder.setChlorinatorOutput(sysId, val));
+                sendUdpCommand(CommandBuilder.setChlorinatorOutput(bridgehandler.getAccount().getToken(),
+                        bridgehandler.getAccount().getMspSystemID(), sysId, val));
                 break;
             default:
                 break;

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardColorLogicHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -18,15 +19,18 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         String sysId = getThing().getProperties().get("systemID");
-        if (sysId == null) {
+        Bridge bridge = getBridge();
+        if (sysId == null || bridge == null || !(bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler)) {
             return;
         }
 
         if ("colorMode".equals(channelUID.getId())) {
-            sendUdpCommand(CommandBuilder.setColorMode(sysId, command.toString()));
+            sendUdpCommand(CommandBuilder.setColorMode(bridgehandler.getAccount().getToken(),
+                    bridgehandler.getAccount().getMspSystemID(), sysId, command.toString()));
         } else if ("brightness".equals(channelUID.getId())) {
             int val = ((Number) command).intValue();
-            sendUdpCommand(CommandBuilder.setBrightness(sysId, val));
+            sendUdpCommand(CommandBuilder.setBrightness(bridgehandler.getAccount().getToken(),
+                    bridgehandler.getAccount().getMspSystemID(), sysId, val));
         }
     }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardFilterHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -18,17 +19,21 @@ public class HaywardFilterHandler extends HaywardThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         String sysId = getThing().getProperties().get("systemID");
-        if (sysId == null) {
+        Bridge bridge = getBridge();
+        if (sysId == null || bridge == null || !(bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler)) {
             return;
         }
 
         switch (channelUID.getId()) {
             case "filterEnable":
-                sendUdpCommand(CommandBuilder.setEquipmentEnable(sysId, "ON".equalsIgnoreCase(command.toString())));
+                sendUdpCommand(CommandBuilder.setEquipmentEnable(bridgehandler.getAccount().getToken(),
+                        bridgehandler.getAccount().getMspSystemID(), sysId,
+                        "ON".equalsIgnoreCase(command.toString())));
                 break;
             case "filterSpeed":
                 int speedVal = ((Number) command).intValue();
-                sendUdpCommand(CommandBuilder.setFilterSpeed(sysId, speedVal));
+                sendUdpCommand(CommandBuilder.setFilterSpeed(bridgehandler.getAccount().getToken(),
+                        bridgehandler.getAccount().getMspSystemID(), sysId, speedVal));
                 break;
             default:
                 break;

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardPumpHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardPumpHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.types.Command;
@@ -18,17 +19,21 @@ public class HaywardPumpHandler extends HaywardThingHandler {
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         String sysId = getThing().getProperties().get("systemID");
-        if (sysId == null) {
+        Bridge bridge = getBridge();
+        if (sysId == null || bridge == null || !(bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler)) {
             return;
         }
 
         switch (channelUID.getId()) {
             case "pumpEnable":
-                sendUdpCommand(CommandBuilder.setEquipmentEnable(sysId, "ON".equalsIgnoreCase(command.toString())));
+                sendUdpCommand(CommandBuilder.setEquipmentEnable(bridgehandler.getAccount().getToken(),
+                        bridgehandler.getAccount().getMspSystemID(), sysId,
+                        "ON".equalsIgnoreCase(command.toString())));
                 break;
             case "pumpSpeed":
                 int speedVal = ((Number) command).intValue();
-                sendUdpCommand(CommandBuilder.setPumpSpeed(sysId, speedVal));
+                sendUdpCommand(CommandBuilder.setPumpSpeed(bridgehandler.getAccount().getToken(),
+                        bridgehandler.getAccount().getMspSystemID(), sysId, speedVal));
                 break;
             default:
                 break;

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/CommandBuilder.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/CommandBuilder.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants;
 
 /**
  * Helper for building XML command strings sent to the Hayward controller.
@@ -30,6 +31,66 @@ public class CommandBuilder {
             </Parameters>
             """;
 
+    private static final String SET_EQUIPMENT_ENABLE = """
+            <Name>SetEquipmentEnable</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"EquipmentID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Enabled\" dataType=\"bool\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_PUMP_SPEED = """
+            <Name>SetPumpSpeed</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"EquipmentID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Speed\" dataType=\"int\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_COLOR_MODE = """
+            <Name>SetColorMode</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"EquipmentID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"ColorMode\" dataType=\"String\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_BRIGHTNESS = """
+            <Name>SetBrightness</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"EquipmentID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Brightness\" dataType=\"int\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_FILTER_SPEED = """
+            <Name>SetFilterSpeed</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"EquipmentID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Speed\" dataType=\"int\">%s</Parameter>
+            </Parameters>
+            """;
+
+    private static final String SET_CHLORINATOR_OUTPUT = """
+            <Name>SetChlorinatorOutput</Name>
+            <Parameters>
+                <Parameter name=\"Token\" dataType=\"String\">%s</Parameter>
+                <Parameter name=\"MspSystemID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"EquipmentID\" dataType=\"int\">%s</Parameter>
+                <Parameter name=\"Output\" dataType=\"int\">%s</Parameter>
+            </Parameters>
+            """;
+
     private CommandBuilder() {
         // utility class
     }
@@ -44,6 +105,40 @@ public class CommandBuilder {
     public static String buildSetUIHeaterCmd(String prefix, String token, int mspSystemID, String poolID,
             String heaterID, String temp) {
         return prefix + String.format(SET_UI_HEATER_CMD, token, mspSystemID, poolID, heaterID, temp)
+                + closingTag(prefix);
+    }
+
+    public static String setEquipmentEnable(String token, String mspSystemID, String equipmentID, boolean enabled) {
+        String prefix = HaywardBindingConstants.COMMAND_PARAMETERS;
+        return prefix
+                + String.format(SET_EQUIPMENT_ENABLE, token, mspSystemID, equipmentID, enabled ? "True" : "False")
+                + closingTag(prefix);
+    }
+
+    public static String setPumpSpeed(String token, String mspSystemID, String equipmentID, int speed) {
+        String prefix = HaywardBindingConstants.COMMAND_PARAMETERS;
+        return prefix + String.format(SET_PUMP_SPEED, token, mspSystemID, equipmentID, speed) + closingTag(prefix);
+    }
+
+    public static String setColorMode(String token, String mspSystemID, String equipmentID, String mode) {
+        String prefix = HaywardBindingConstants.COMMAND_PARAMETERS;
+        return prefix + String.format(SET_COLOR_MODE, token, mspSystemID, equipmentID, mode) + closingTag(prefix);
+    }
+
+    public static String setBrightness(String token, String mspSystemID, String equipmentID, int brightness) {
+        String prefix = HaywardBindingConstants.COMMAND_PARAMETERS;
+        return prefix + String.format(SET_BRIGHTNESS, token, mspSystemID, equipmentID, brightness)
+                + closingTag(prefix);
+    }
+
+    public static String setFilterSpeed(String token, String mspSystemID, String equipmentID, int speed) {
+        String prefix = HaywardBindingConstants.COMMAND_PARAMETERS;
+        return prefix + String.format(SET_FILTER_SPEED, token, mspSystemID, equipmentID, speed) + closingTag(prefix);
+    }
+
+    public static String setChlorinatorOutput(String token, String mspSystemID, String equipmentID, int output) {
+        String prefix = HaywardBindingConstants.COMMAND_PARAMETERS;
+        return prefix + String.format(SET_CHLORINATOR_OUTPUT, token, mspSystemID, equipmentID, output)
                 + closingTag(prefix);
     }
 


### PR DESCRIPTION
## Summary
- add XML templates and helpers for equipment control
- wire pump, filter, color logic, and chlorinator handlers to new commands

## Testing
- `mvn -q -pl :org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7116274832391de992c8f57c21f