### PR TITLE
Define messageId variable in UdpResponseTest

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
@@ -21,6 +21,7 @@ public class UdpResponseTest {
     @Test
     public void fromBytesShouldParseHeaderAndXml() throws Exception {
         int messageType = 1004;
+        int messageId = 0x01020304;
         byte[] xmlBytes = RESPONSE_XML.getBytes(StandardCharsets.UTF_8);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (DeflaterOutputStream deflater = new DeflaterOutputStream(baos)) {
@@ -28,7 +29,7 @@ public class UdpResponseTest {
         }
         byte[] compressed = baos.toByteArray();
         ByteBuffer buffer = ByteBuffer.allocate(24 + compressed.length);
-        buffer.putInt(0x01020304);
+        buffer.putInt(messageId);
 
         buffer.putLong(0x0102030405060708L);
         buffer.put("1.22".getBytes(StandardCharsets.US_ASCII));


### PR DESCRIPTION
## Summary
- replace hardcoded message ID with variable in UdpResponseTest

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom: No versions matched the requested parent version range '[1.0, 2.0)')*
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*


------
https://chatgpt.com/codex/tasks/task_e_68c0aa254cfc8323ad32e3bf4e42f552