### PR TITLE
fix(hayward): include message id in UDP response

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponse.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponse.java
@@ -89,6 +89,6 @@ public class UdpResponse {
             xml = new String(payload, StandardCharsets.UTF_8).trim();
         }
 
-        return new UdpResponse(msgType, xml);
+        return new UdpResponse(msgId, msgType, xml);
     }
 }


### PR DESCRIPTION
## Summary
- ensure `UdpResponse.fromBytes` includes message id when constructing responses

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa479dac8323a1d7274f542f5d29