### PR TITLE
Parse MSP system ID before issuing Hayward virtual heater commands

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardVirtualHeaterHandler.java
@@ -121,6 +121,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
         if (bridge != null && bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler) {
             String cmdString = this.cmdToString(command);
             String cmdURL = null;
+            int mspId = Integer.parseInt(bridgehandler.getAccount().getMspSystemID());
 
             if (command == OnOffType.ON) {
                 cmdString = "True";
@@ -132,8 +133,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
                         cmdURL = CommandBuilder.buildSetHeaterEnable(HaywardBindingConstants.COMMAND_PARAMETERS,
-                                bridgehandler.account.token, bridgehandler.account.mspSystemID, poolID, systemID,
-                                cmdString);
+                                bridgehandler.getAccount().getToken(), mspId, poolID, systemID, cmdString);
                         break;
 
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
@@ -145,8 +145,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                             }
                         }
                         cmdURL = CommandBuilder.buildSetUIHeaterCmd(HaywardBindingConstants.COMMAND_PARAMETERS,
-                                bridgehandler.account.token, bridgehandler.account.mspSystemID, poolID, systemID,
-                                cmdString);
+                                bridgehandler.getAccount().getToken(), mspId, poolID, systemID, cmdString);
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
@@ -121,6 +121,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
         if (bridge != null && bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler) {
             String cmdString = this.cmdToString(command);
             String cmdURL = null;
+            int mspId = Integer.parseInt(bridgehandler.getAccount().getMspSystemID());
 
             if (command == OnOffType.ON) {
                 cmdString = "True";
@@ -132,8 +133,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
                         cmdURL = CommandBuilder.buildSetHeaterEnable(HaywardBindingConstants.COMMAND_PARAMETERS,
-                                bridgehandler.getAccount().getToken(), bridgehandler.getAccount().getMspSystemID(),
-                                poolID, systemID, cmdString);
+                                bridgehandler.getAccount().getToken(), mspId, poolID, systemID, cmdString);
                         break;
 
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
@@ -146,8 +146,7 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                         }
 
                         cmdURL = CommandBuilder.buildSetUIHeaterCmd(HaywardBindingConstants.COMMAND_PARAMETERS,
-                                bridgehandler.getAccount().getToken(), bridgehandler.getAccount().getMspSystemID(),
-                                poolID, systemID, cmdString);
+                                bridgehandler.getAccount().getToken(), mspId, poolID, systemID, cmdString);
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);


### PR DESCRIPTION
## Summary
- Parse bridge MSP system ID once in Hayward virtual heater handlers
- Use getter for account and pass parsed MSP ID into command builders

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogic,bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa6330088323bf8e1db15a6b9c5d