### PR TITLE
Define handshake XML request and ensure boolean return

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
@@ -164,6 +164,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     }
 
     private synchronized boolean handshake() throws HaywardException {
+        String xmlRequest = "<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?><Request><Name>RequestConfiguration</Name></Request>";
 
         String xmlResponse = udpXmlResponse(xmlRequest, MSG_TYPE_REQUEST);
 
@@ -171,6 +172,8 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
             logger.debug("Hayward Connection thing: Handshake XML response was null");
             return false;
         }
+
+        return true;
     }
 
     @Deprecated


### PR DESCRIPTION
## Summary
- Add RequestConfiguration XML payload for Hayward UDP handshake
- Ensure handshake method always returns boolean after verifying response

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa2a8e0083238300031239c91f2a