### PR TITLE
fix: handle null IDs and token in virtual heater

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants;
@@ -121,6 +122,14 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
         if (bridge != null && bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler) {
             String cmdString = this.cmdToString(command);
             String cmdURL = null;
+            String token = bridgehandler.getAccount().getToken();
+
+            if (poolID == null || systemID == null || token == null) {
+                logger.warn("haywardCommand missing configuration (poolID={}, systemID={}, token={})", poolID,
+                        systemID, token);
+                return;
+            }
+
             int mspId = Integer.parseInt(bridgehandler.getAccount().getMspSystemID());
 
             if (command == OnOffType.ON) {
@@ -133,7 +142,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                 switch (channelUID.getId()) {
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE:
                         cmdURL = CommandBuilder.buildSetHeaterEnable(HaywardBindingConstants.COMMAND_PARAMETERS,
-                                bridgehandler.getAccount().getToken(), mspId, poolID, systemID, cmdString);
+                                Objects.requireNonNull(token), mspId, Objects.requireNonNull(poolID),
+                                Objects.requireNonNull(systemID), cmdString);
                         break;
 
                     case HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT:
@@ -146,7 +156,8 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
                         }
 
                         cmdURL = CommandBuilder.buildSetUIHeaterCmd(HaywardBindingConstants.COMMAND_PARAMETERS,
-                                bridgehandler.getAccount().getToken(), mspId, poolID, systemID, cmdString);
+                                Objects.requireNonNull(token), mspId, Objects.requireNonNull(poolID),
+                                Objects.requireNonNull(systemID), cmdString);
                         break;
                     default:
                         logger.warn("haywardCommand Unsupported type {}", channelUID);


### PR DESCRIPTION
## Summary
- check poolID, systemID and token for null before sending commands
- use Objects.requireNonNull when building heater commands

## Testing
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom:[1.0, 2.0))*

------
https://chatgpt.com/codex/tasks/task_e_68c0ad052e00832381cd082bc903b8c2