### PR TITLE
feat: throw on missing UDP response

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -120,6 +120,9 @@ public class UdpClient {
         } catch (UnsupportedEncodingException e) {
             throw new IOException(e);
         }
+        if (response == null) {
+            throw new IOException("No UDP response received");
+        }
         return response;
     }
 


### PR DESCRIPTION
## Summary
- throw IOException when no UDP response is received in UdpClient

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ad0c372883239ae23be0c996c804