### PR TITLE
fix: remove duplicate messageId declaration

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
@@ -22,7 +22,6 @@ public class UdpResponseTest {
     public void fromBytesShouldParseHeaderAndXml() throws Exception {
         int messageId = 0x01020304;
         int messageType = 1004;
-        int messageId = 0x01020304;
         byte[] xmlBytes = RESPONSE_XML.getBytes(StandardCharsets.UTF_8);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (DeflaterOutputStream deflater = new DeflaterOutputStream(baos)) {


### PR DESCRIPTION
## Summary
- remove duplicate messageId variable in UdpResponseTest

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Failed to fetch apache maven)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ad0fa298832383ad1c0e6659c0e5