### PR TITLE
haywardomnilogiclocal: handle compression flag in multi-block responses

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -73,10 +73,8 @@ public class UdpClient {
                 buffer.getLong();
                 buffer.position(16);
                 int msgType = buffer.getInt();
-                buffer.get();
-                int blockCount = Byte.toUnsignedInt(buffer.get());
-                boolean thisCompressed = buffer.get() != 0;
-                buffer.get();
+                int blockCount = Byte.toUnsignedInt(data[21]);
+                boolean thisCompressed = data[22] == 1;
 
                 if (!ackSent && (msgType == MSG_LEAD || msgType == MSG_BLOCK
                         || msgType == HaywardMessageType.MSP_TELEMETRY_UPDATE.getMsgInt())) {
@@ -88,6 +86,7 @@ public class UdpClient {
                     expectedBlocks = blockCount;
                     compressed = thisCompressed;
                 } else if (msgType == MSG_BLOCK) {
+                    compressed |= thisCompressed;
                     blocks.write(data, 24, data.length - 24);
                     expectedBlocks--;
                     if (expectedBlocks == 0) {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -4,13 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.DeflaterOutputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -102,6 +105,86 @@ public class UdpClientTest {
         assertTrue(ackAfterLead.get());
     }
 
+    @Test
+    public void sendShouldHandleUncompressedMultiBlockResponse() throws Exception {
+        final DatagramSocket server = new DatagramSocket(0);
+        final int port = server.getLocalPort();
+        final String responseXml = "<Response>OK</Response>";
+        byte[] xmlBytes = (responseXml + '\0').getBytes(StandardCharsets.UTF_8);
+        int mid = xmlBytes.length / 2;
+        byte[] part1 = Arrays.copyOfRange(xmlBytes, 0, mid);
+        byte[] part2 = Arrays.copyOfRange(xmlBytes, mid, xmlBytes.length);
+
+        Thread serverThread = new Thread(() -> {
+            try {
+                byte[] buf = new byte[4096];
+                DatagramPacket requestPacket = new DatagramPacket(buf, buf.length);
+                server.receive(requestPacket);
+                int msgId = ByteBuffer.wrap(requestPacket.getData(), 0, requestPacket.getLength()).getInt();
+                InetAddress clientAddress = requestPacket.getAddress();
+                int clientPort = requestPacket.getPort();
+                byte[] lead = createLeadPacket(msgId, 2, false);
+                server.send(new DatagramPacket(lead, lead.length, clientAddress, clientPort));
+                byte[] block1 = createBlockPacket(msgId, part1, false);
+                server.send(new DatagramPacket(block1, block1.length, clientAddress, clientPort));
+                byte[] block2 = createBlockPacket(msgId, part2, false);
+                server.send(new DatagramPacket(block2, block2.length, clientAddress, clientPort));
+            } catch (Exception e) {
+                // ignore for test
+            }
+        });
+        serverThread.start();
+
+        UdpClient client = new UdpClient("127.0.0.1", port);
+        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY.getMsgInt(), "<Request/>");
+        UdpResponse response = client.send(request);
+
+        serverThread.join();
+        server.close();
+
+        assertEquals(responseXml, response.getXml());
+    }
+
+    @Test
+    public void sendShouldDecompressMultiBlockResponseWhenFlagSet() throws Exception {
+        final DatagramSocket server = new DatagramSocket(0);
+        final int port = server.getLocalPort();
+        final String responseXml = "<Response>OK</Response>";
+        byte[] compressed = compress(responseXml);
+        int mid = compressed.length / 2;
+        byte[] part1 = Arrays.copyOfRange(compressed, 0, mid);
+        byte[] part2 = Arrays.copyOfRange(compressed, mid, compressed.length);
+
+        Thread serverThread = new Thread(() -> {
+            try {
+                byte[] buf = new byte[4096];
+                DatagramPacket requestPacket = new DatagramPacket(buf, buf.length);
+                server.receive(requestPacket);
+                int msgId = ByteBuffer.wrap(requestPacket.getData(), 0, requestPacket.getLength()).getInt();
+                InetAddress clientAddress = requestPacket.getAddress();
+                int clientPort = requestPacket.getPort();
+                byte[] lead = createLeadPacket(msgId, 2, true);
+                server.send(new DatagramPacket(lead, lead.length, clientAddress, clientPort));
+                byte[] block1 = createBlockPacket(msgId, part1, true);
+                server.send(new DatagramPacket(block1, block1.length, clientAddress, clientPort));
+                byte[] block2 = createBlockPacket(msgId, part2, true);
+                server.send(new DatagramPacket(block2, block2.length, clientAddress, clientPort));
+            } catch (Exception e) {
+                // ignore for test
+            }
+        });
+        serverThread.start();
+
+        UdpClient client = new UdpClient("127.0.0.1", port);
+        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY.getMsgInt(), "<Request/>");
+        UdpResponse response = client.send(request);
+
+        serverThread.join();
+        server.close();
+
+        assertEquals(responseXml, response.getXml());
+    }
+
     private static byte[] createAckPacket(int messageId) throws Exception {
         UdpRequest ack = new UdpRequest(HaywardMessageType.ACK.getMsgInt(), "ACK", messageId);
         return ack.toBytes();
@@ -121,7 +204,10 @@ public class UdpClientTest {
     }
 
     private static byte[] createBlockPacket(int messageId, String xml) {
-        byte[] xmlBytes = (xml + '\0').getBytes(StandardCharsets.UTF_8);
+        return createBlockPacket(messageId, (xml + '\0').getBytes(StandardCharsets.UTF_8), false);
+    }
+
+    private static byte[] createBlockPacket(int messageId, byte[] data, boolean compressed) {
         ByteBuffer header = ByteBuffer.allocate(24);
         header.putInt(messageId);
         header.putLong(System.currentTimeMillis());
@@ -129,12 +215,20 @@ public class UdpClientTest {
         header.putInt(HaywardMessageType.MSP_BLOCKMESSAGE.getMsgInt());
         header.put((byte) 1);
         header.put((byte) 0);
+        header.put((byte) (compressed ? 1 : 0));
         header.put((byte) 0);
-        header.put((byte) 0);
-        byte[] packet = new byte[24 + xmlBytes.length];
+        byte[] packet = new byte[24 + data.length];
         System.arraycopy(header.array(), 0, packet, 0, 24);
-        System.arraycopy(xmlBytes, 0, packet, 24, xmlBytes.length);
+        System.arraycopy(data, 0, packet, 24, data.length);
         return packet;
+    }
+
+    private static byte[] compress(String xml) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DeflaterOutputStream dos = new DeflaterOutputStream(baos)) {
+            dos.write(xml.getBytes(StandardCharsets.UTF_8));
+        }
+        return baos.toByteArray();
     }
 }
 


### PR DESCRIPTION
## Summary
- track packet compression via header byte 22 when receiving UDP responses
- decompress concatenated block payloads when header compression flag is set
- add tests for compressed and uncompressed multi-block responses

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom: No versions matched the requested parent version range '[1.0, 2.0)')*

------
https://chatgpt.com/codex/tasks/task_e_68c0dcc41c2c8323a0d3c8eeaa7f7726