### PR TITLE
Parse Hayward block metadata from lead XML

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -73,10 +73,7 @@ public class UdpClient {
                 buffer.getLong();
                 buffer.position(16);
                 int msgType = buffer.getInt();
-                buffer.get();
-                int blockCount = Byte.toUnsignedInt(buffer.get());
-                boolean thisCompressed = buffer.get() != 0;
-                buffer.get();
+                buffer.position(24);
 
                 if (!ackSent && (msgType == MSG_LEAD || msgType == MSG_BLOCK
                         || msgType == HaywardMessageType.MSP_TELEMETRY_UPDATE.getMsgInt())) {
@@ -85,8 +82,9 @@ public class UdpClient {
                 }
 
                 if (msgType == MSG_LEAD) {
-                    expectedBlocks = blockCount;
-                    compressed = thisCompressed;
+                    String xml = new String(data, 24, data.length - 24, StandardCharsets.UTF_8).trim();
+                    expectedBlocks = parseIntParameter(xml, "MsgBlockCount");
+                    compressed = parseIntParameter(xml, "Type") == 1;
                 } else if (msgType == MSG_BLOCK) {
                     blocks.write(data, 24, data.length - 24);
                     expectedBlocks--;
@@ -126,6 +124,24 @@ public class UdpClient {
             throw new IOException("No UDP response received");
         }
         return response;
+    }
+
+    private static int parseIntParameter(String xml, String name) {
+        String search = "<Parameter name=\"" + name + "\">";
+        int start = xml.indexOf(search);
+        if (start == -1) {
+            return 0;
+        }
+        start += search.length();
+        int end = xml.indexOf("</Parameter>", start);
+        if (end == -1) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(xml.substring(start, end));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     private void sendAck(DatagramSocket socket, int messageId) throws IOException {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -108,16 +108,20 @@ public class UdpClientTest {
     }
 
     private static byte[] createLeadPacket(int messageId, int blocks, boolean compressed) {
-        ByteBuffer buffer = ByteBuffer.allocate(24);
-        buffer.putInt(messageId);
-        buffer.putLong(System.currentTimeMillis());
-        buffer.put("1.22".getBytes(StandardCharsets.US_ASCII));
-        buffer.putInt(HaywardMessageType.MSP_LEADMESSAGE.getMsgInt());
-        buffer.put((byte) 1);
-        buffer.put((byte) blocks);
-        buffer.put((byte) (compressed ? 1 : 0));
-        buffer.put((byte) 0);
-        return buffer.array();
+        String xml = "<Message><Parameter name=\"MsgBlockCount\">" + blocks
+                + "</Parameter><Parameter name=\"Type\">" + (compressed ? 1 : 0) + "</Parameter></Message>";
+        byte[] xmlBytes = (xml + '\0').getBytes(StandardCharsets.UTF_8);
+        ByteBuffer header = ByteBuffer.allocate(24);
+        header.putInt(messageId);
+        header.putLong(System.currentTimeMillis());
+        header.put("1.22".getBytes(StandardCharsets.US_ASCII));
+        header.putInt(HaywardMessageType.MSP_LEADMESSAGE.getMsgInt());
+        header.put((byte) 1);
+        header.put(new byte[3]);
+        byte[] packet = new byte[24 + xmlBytes.length];
+        System.arraycopy(header.array(), 0, packet, 0, 24);
+        System.arraycopy(xmlBytes, 0, packet, 24, xmlBytes.length);
+        return packet;
     }
 
     private static byte[] createBlockPacket(int messageId, String xml) {
@@ -128,9 +132,7 @@ public class UdpClientTest {
         header.put("1.22".getBytes(StandardCharsets.US_ASCII));
         header.putInt(HaywardMessageType.MSP_BLOCKMESSAGE.getMsgInt());
         header.put((byte) 1);
-        header.put((byte) 0);
-        header.put((byte) 0);
-        header.put((byte) 0);
+        header.put(new byte[3]);
         byte[] packet = new byte[24 + xmlBytes.length];
         System.arraycopy(header.array(), 0, packet, 0, 24);
         System.arraycopy(xmlBytes, 0, packet, 24, xmlBytes.length);


### PR DESCRIPTION
## Summary
- Derive block count and compression flag from lead XML instead of UDP header
- Drop unused header parsing and add helper for Parameter extraction
- Update tests to embed block metadata in lead message payload

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c15605392c83238c3de5d0960a283b