### PR TITLE
fix: map Parameter value attribute

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -34,7 +34,8 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamValue;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
 
 /**
@@ -63,11 +64,11 @@ public class UdpClient {
     }
 
     @XStreamAlias("Parameter")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "value" })
     private static class Parameter {
         @XStreamAsAttribute
         private @Nullable String name;
 
-        @XStreamValue
         private @Nullable String value;
     }
 


### PR DESCRIPTION
## Summary
- map XStream `Parameter` value directly to text content via `ToAttributedValueConverter`

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am -DskipTests clean package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a03a58a483239ca8c2041e3dda5e