### PR TITLE
Alias Response element for XStream parsing in OmniLogic binding

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -52,6 +52,7 @@ public class UdpClient {
 
     static {
         XSTREAM.allowTypes(new Class[] { Message.class, Parameter.class });
+        XSTREAM.alias("Response", Message.class);
         XSTREAM.setClassLoader(UdpClient.class.getClassLoader());
         XSTREAM.ignoreUnknownElements();
         XSTREAM.processAnnotations(Message.class);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.DeflaterOutputStream;
+import java.lang.reflect.Method;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -103,6 +104,15 @@ public class UdpClientTest {
         assertEquals(responseXml, response.getXml());
         assertFalse(ackBeforeLead.get());
         assertTrue(ackAfterLead.get());
+    }
+
+    @Test
+    public void parseIntParameterShouldHandleResponseRoot() throws Exception {
+        Method method = UdpClient.class.getDeclaredMethod("parseIntParameter", String.class, String.class);
+        method.setAccessible(true);
+        String xml = "<Response><Parameter name=\"Test\">42</Parameter></Response>";
+        int value = (int) method.invoke(null, xml, "Test");
+        assertEquals(42, value);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- treat `<Response>` tags as `Message` for XStream parsing to avoid `CannotResolveClassException`
- add unit test ensuring `parseIntParameter` handles `Response` roots

## Testing
- `./mvnw -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: wget unable to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af58e64c83238301151667827731