### PR TITLE
Ensure null-safe unboxing in UdpClientTest

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -12,6 +12,7 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.DeflaterOutputStream;
 import java.lang.reflect.Method;
@@ -111,7 +112,7 @@ public class UdpClientTest {
         Method method = UdpClient.class.getDeclaredMethod("parseIntParameter", String.class, String.class);
         method.setAccessible(true);
         String xml = "<Response><Parameter name=\"Test\">42</Parameter></Response>";
-        int value = (int) method.invoke(null, xml, "Test");
+        int value = (Integer) Objects.requireNonNull(method.invoke(null, xml, "Test"));
         assertEquals(42, value);
     }
 


### PR DESCRIPTION
## Summary
- prevent potential NPE in UdpClientTest by unboxing via Objects.requireNonNull
- add Objects import

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c60b0ef083239ac9ea231fa24aa3