### PR TITLE
Fix reflection target in UdpClientTest

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -112,7 +112,7 @@ public class UdpClientTest {
         Method method = UdpClient.class.getDeclaredMethod("parseIntParameter", String.class, String.class);
         method.setAccessible(true);
         String xml = "<Response><Parameter name=\"Test\">42</Parameter></Response>";
-        int value = (Integer) Objects.requireNonNull(method.invoke(null, xml, "Test"));
+        int value = (Integer) Objects.requireNonNull(method.invoke(UdpClient.class, xml, "Test"));
         assertEquals(42, value);
     }
 


### PR DESCRIPTION
## Summary
- adjust reflection invocation in `UdpClientTest` to use `UdpClient.class` instead of `null`

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c9ea9f6c83239d19870796b39407