### PR TITLE
Send ACK for each block in OmniLogic UDP client

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClient.java
@@ -74,7 +74,6 @@ public class UdpClient {
             ByteArrayOutputStream blocks = new ByteArrayOutputStream();
             int expectedBlocks = 0;
             boolean compressed = false;
-            boolean ackSent = false;
 
             while (true) {
                 byte[] buf = new byte[4096];
@@ -93,11 +92,9 @@ public class UdpClient {
               
                 boolean thisCompressed = data[22] == 1;
 
-
-                if (!ackSent && (msgType == MSG_LEAD || msgType == MSG_BLOCK
-                        || msgType == HaywardMessageType.MSP_TELEMETRY_UPDATE.getMsgInt())) {
+                if (msgType == MSG_LEAD || msgType == MSG_BLOCK
+                        || msgType == HaywardMessageType.MSP_TELEMETRY_UPDATE.getMsgInt()) {
                     sendAck(socket, msgId);
-                    ackSent = true;
                 }
 
                 if (msgType == MSG_LEAD) {


### PR DESCRIPTION
## Summary
- always send ACK for each lead and block UDP message
- test that ACKs are emitted for multiple sequential blocks

## Testing
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c21bb5c4bc8323a573591fab71b33d