### PR TITLE
Use HaywardMessageType enum in UDP client

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardMessageType.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardMessageType.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The type to request.
@@ -47,5 +48,14 @@ public enum HaywardMessageType {
 
     public int getMsgInt() {
         return msgInt;
+    }
+
+    public static @Nullable HaywardMessageType fromMsgInt(int msgInt) {
+        for (HaywardMessageType type : values()) {
+            if (type.msgInt == msgInt) {
+                return type;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- add mapping helper to `HaywardMessageType`
- parse UDP response types into the enum instead of raw ints

## Testing
- `mvn -q -pl :org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c21cf49c9c832384148154a8278cf7