### PR TITLE
Fix Hayward OmniLogic local test compilation

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -97,7 +109,7 @@ public class UdpClientTest {
         serverThread.start();
 
         UdpClient client = new UdpClient("127.0.0.1", port);
-        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY.getMsgInt(), "<Request/>");
+        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY, "<Request/>");
         UdpResponse response = client.send(request);
 
         serverThread.join();
@@ -179,7 +191,7 @@ public class UdpClientTest {
         serverThread.start();
 
         UdpClient client = new UdpClient("127.0.0.1", port);
-        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY.getMsgInt(), "<Request/>");
+        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY, "<Request/>");
         UdpResponse response = client.send(request);
 
         serverThread.join();
@@ -221,7 +233,7 @@ public class UdpClientTest {
         serverThread.start();
 
         UdpClient client = new UdpClient("127.0.0.1", port);
-        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY.getMsgInt(), "<Request/>");
+        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY, "<Request/>");
         UdpResponse response = client.send(request);
 
         serverThread.join();
@@ -231,7 +243,7 @@ public class UdpClientTest {
     }
 
     private static byte[] createAckPacket(int messageId) throws Exception {
-        UdpRequest ack = new UdpRequest(HaywardMessageType.ACK.getMsgInt(), "ACK", messageId);
+        UdpRequest ack = new UdpRequest(HaywardMessageType.ACK, "ACK", messageId);
         return ack.toBytes();
     }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequestTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequestTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 
 /**
  * Tests for {@link UdpRequest}.
@@ -18,7 +31,7 @@ public class UdpRequestTest {
 
     @Test
     public void toBytesShouldCreateHeaderAndPayload() throws Exception {
-        int messageType = 1004;
+        HaywardMessageType messageType = HaywardMessageType.MSP_TELEMETRY_UPDATE;
         UdpRequest request = new UdpRequest(messageType, REQUEST_XML);
 
         byte[] bytes = request.toBytes();
@@ -30,7 +43,7 @@ public class UdpRequestTest {
         assertEquals("1.22", version);
 
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        assertEquals(messageType, buffer.getInt(16));
+        assertEquals(messageType.getMsgInt(), buffer.getInt(16));
 
         assertEquals(1, bytes[20]);
         assertEquals(0, bytes[21]);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponseTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
## Summary
- Add standard EPL-2.0 header to UdpClientTest, UdpRequestTest, and UdpResponseTest
- Update haywardomnilogiclocal tests to use enum-based UdpRequest constructor

## Testing
- `mvn -q -pl :org.openhab.binding.haywardomnilogiclocal test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ccc2b2fc832396ae28ca57228b62