### PR TITLE
feat(hayward): unify UDP message handling

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
@@ -40,8 +40,7 @@ import org.openhab.binding.haywardomnilogiclocal.internal.HaywardTypeToRequest;
 import org.openhab.binding.haywardomnilogiclocal.internal.config.HaywardConfig;
 import org.openhab.binding.haywardomnilogiclocal.internal.discovery.HaywardDiscoveryService;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.UdpClient;
-import org.openhab.binding.haywardomnilogiclocal.internal.net.UdpRequest;
-import org.openhab.binding.haywardomnilogiclocal.internal.net.UdpResponse;
+import org.openhab.binding.haywardomnilogiclocal.internal.net.UdpMessage;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -304,7 +303,7 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
         }
 
         try {
-            UdpResponse response = udpClient.send(new UdpRequest(msgType, xmlRequest));
+            UdpMessage response = udpClient.send(msgType, xmlRequest);
             return response.getXml();
         } catch (IOException e) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/AckHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/AckHandler.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
-import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
@@ -36,18 +35,11 @@ public class AckHandler {
     }
 
     public void sendAck(DatagramSocket socket, int messageId) throws IOException {
-        UdpHeader header = new UdpHeader(HaywardMessageType.ACK, messageId);
-        byte[] headerBytes = header.toBytes();
-        byte[] xml = "ACK\0".getBytes(StandardCharsets.UTF_8);
-        byte[] out = new byte[headerBytes.length + xml.length];
-        System.arraycopy(headerBytes, 0, out, 0, headerBytes.length);
-        System.arraycopy(xml, 0, out, headerBytes.length, xml.length);
-
+        byte[] out = UdpMessage.encodeRequest(HaywardMessageType.ACK, "ACK", messageId);
         DatagramPacket packet = new DatagramPacket(out, out.length, address, port);
         socket.send(packet);
 
-        UdpRequest ack = new UdpRequest(HaywardMessageType.ACK, "", messageId);
-        byte[] ackBytes = ack.toBytes();
+        byte[] ackBytes = UdpMessage.encodeRequest(HaywardMessageType.ACK, "", messageId);
         DatagramPacket ackPacket = new DatagramPacket(ackBytes, ackBytes.length, address, port);
         socket.send(ackPacket);
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessage.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessage.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogiclocal.internal.net;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.zip.InflaterInputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
+
+/**
+ * Represents a UDP message exchanged with the OmniLogic controller.
+ *
+ * @author Matt Myers - Initial contribution
+ */
+@NonNullByDefault
+public class UdpMessage {
+
+    private final UdpHeader header;
+    private final String xml;
+
+    UdpMessage(UdpHeader header, String xml) {
+        this.header = header;
+        this.xml = xml;
+    }
+
+    public UdpHeader getHeader() {
+        return header;
+    }
+
+    public HaywardMessageType getMessageType() {
+        return header.getMessageType();
+    }
+
+    public int getMessageId() {
+        return header.getMessageId();
+    }
+
+    public String getXml() {
+        return xml;
+    }
+
+    /**
+     * Encodes a request message for sending to the controller.
+     */
+    public static byte[] encodeRequest(HaywardMessageType msgType, String xml, @Nullable Integer messageId)
+            throws UnsupportedEncodingException {
+        Random random = new Random();
+        int msgId = messageId != null ? messageId.intValue() : random.nextInt();
+        UdpHeader header = new UdpHeader(msgType, msgId);
+        byte[] headerBytes = header.toBytes();
+        byte[] xmlBytes = (xml + '\0').getBytes("UTF-8");
+
+        byte[] packet = new byte[headerBytes.length + xmlBytes.length];
+        System.arraycopy(headerBytes, 0, packet, 0, headerBytes.length);
+        System.arraycopy(xmlBytes, 0, packet, headerBytes.length, xmlBytes.length);
+        return packet;
+    }
+
+    /**
+     * Convenience method to encode a request with no explicit message id.
+     */
+    public static byte[] encodeRequest(HaywardMessageType msgType, String xml) throws UnsupportedEncodingException {
+        return encodeRequest(msgType, xml, null);
+    }
+
+    /**
+     * Decodes a response message received from the controller.
+     */
+    public static UdpMessage decodeResponse(byte[] data, int length) throws UnsupportedEncodingException {
+        UdpHeader header = UdpHeader.fromBytes(data);
+        byte[] payload = new byte[length - UdpHeader.HEADER_LENGTH];
+        System.arraycopy(data, UdpHeader.HEADER_LENGTH, payload, 0, payload.length);
+
+        String xml;
+        if (header.getMessageType() == HaywardMessageType.MSP_TELEMETRY_UPDATE) {
+            try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(payload));
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                byte[] buf = new byte[1024];
+                int read;
+                while ((read = inflater.read(buf)) != -1) {
+                    baos.write(buf, 0, read);
+                }
+                xml = baos.toString(StandardCharsets.UTF_8.name()).trim();
+            } catch (IOException e) {
+                UnsupportedEncodingException ex = new UnsupportedEncodingException(e.getMessage());
+                ex.initCause(e);
+                throw ex;
+            }
+        } else {
+            xml = new String(payload, StandardCharsets.UTF_8).trim();
+        }
+
+        return new UdpMessage(header, xml);
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpRequest.java
@@ -27,6 +27,7 @@ import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
  * document terminated with a null character. Only the fields required for the
  * binding are modelled here.
  */
+@Deprecated(forRemoval = true)
 @NonNullByDefault
 public class UdpRequest {
     private final HaywardMessageType messageType;
@@ -45,17 +46,11 @@ public class UdpRequest {
 
     /**
      * Serialises the request to the binary format expected by the controller.
+     *
+     * @deprecated Use {@link UdpMessage#encodeRequest(HaywardMessageType, String, Integer)} instead.
      */
+    @Deprecated(forRemoval = true)
     public byte[] toBytes() throws UnsupportedEncodingException {
-        Random random = new Random();
-        int msgID = messageId != null ? messageId.intValue() : random.nextInt();
-        UdpHeader header = new UdpHeader(messageType, msgID);
-        byte[] headerBytes = header.toBytes();
-        byte[] xmlBytes = (xml + '\0').getBytes("UTF-8");
-
-        byte[] packet = new byte[headerBytes.length + xmlBytes.length];
-        System.arraycopy(headerBytes, 0, packet, 0, headerBytes.length);
-        System.arraycopy(xmlBytes, 0, packet, headerBytes.length, xmlBytes.length);
-        return packet;
+        return UdpMessage.encodeRequest(messageType, xml, messageId);
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponse.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpResponse.java
@@ -13,68 +13,43 @@
 
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.zip.InflaterInputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 
 /**
  * Represents a UDP response from the OmniLogic controller.
+ *
+ * @deprecated Use {@link UdpMessage} instead.
  */
+@Deprecated(forRemoval = true)
 @NonNullByDefault
 public class UdpResponse {
-    private final UdpHeader header;
-    private final String xml;
+    private final UdpMessage message;
 
-    private UdpResponse(UdpHeader header, String xml) {
-        this.header = header;
-        this.xml = xml;
+    private UdpResponse(UdpMessage message) {
+        this.message = message;
     }
 
     public int getMessageType() {
-        return header.getMessageType().getMsgInt();
+        return message.getMessageType().getMsgInt();
     }
 
     public int getMessageId() {
-        return header.getMessageId();
+        return message.getMessageId();
     }
 
     public String getXml() {
-        return xml;
+        return message.getXml();
     }
 
     /**
      * Decodes the raw packet received from the controller.
+     *
+     * @deprecated Use {@link UdpMessage#decodeResponse(byte[], int)} instead.
      */
+    @Deprecated(forRemoval = true)
     public static UdpResponse fromBytes(byte[] data, int length) throws UnsupportedEncodingException {
-        UdpHeader header = UdpHeader.fromBytes(data);
-        byte[] payload = new byte[length - UdpHeader.HEADER_LENGTH];
-        System.arraycopy(data, UdpHeader.HEADER_LENGTH, payload, 0, payload.length);
-
-        String xml;
-        if (header.getMessageType() == HaywardMessageType.MSP_TELEMETRY_UPDATE) {
-            try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(payload));
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                byte[] buf = new byte[1024];
-                int read;
-                while ((read = inflater.read(buf)) != -1) {
-                    baos.write(buf, 0, read);
-                }
-                xml = baos.toString(StandardCharsets.UTF_8.name()).trim();
-            } catch (IOException e) {
-                UnsupportedEncodingException ex = new UnsupportedEncodingException(e.getMessage());
-                ex.initCause(e);
-                throw ex;
-            }
-        } else {
-            xml = new String(payload, StandardCharsets.UTF_8).trim();
-        }
-
-        return new UdpResponse(header, xml);
+        return new UdpResponse(UdpMessage.decodeResponse(data, length));
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpClientTest.java
@@ -109,13 +109,12 @@ public class UdpClientTest {
         serverThread.start();
 
         UdpClient client = new UdpClient("127.0.0.1", port);
-        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY, "<Request/>");
-        UdpResponse response = client.send(request);
+        UdpMessage response = client.send(HaywardMessageType.GET_TELEMETRY, "<Request/>");
 
         serverThread.join();
         server.close();
 
-        assertEquals(HaywardMessageType.MSP_BLOCKMESSAGE.getMsgInt(), response.getMessageType());
+        assertEquals(HaywardMessageType.MSP_BLOCKMESSAGE.getMsgInt(), response.getMessageType().getMsgInt());
         assertEquals(responseXml, response.getXml());
         assertFalse(ackBeforeLead.get());
         assertTrue(ackAfterLead.get());
@@ -191,8 +190,7 @@ public class UdpClientTest {
         serverThread.start();
 
         UdpClient client = new UdpClient("127.0.0.1", port);
-        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY, "<Request/>");
-        UdpResponse response = client.send(request);
+        UdpMessage response = client.send(HaywardMessageType.GET_TELEMETRY, "<Request/>");
 
         serverThread.join();
         server.close();
@@ -233,8 +231,7 @@ public class UdpClientTest {
         serverThread.start();
 
         UdpClient client = new UdpClient("127.0.0.1", port);
-        UdpRequest request = new UdpRequest(HaywardMessageType.GET_TELEMETRY, "<Request/>");
-        UdpResponse response = client.send(request);
+        UdpMessage response = client.send(HaywardMessageType.GET_TELEMETRY, "<Request/>");
 
         serverThread.join();
         server.close();
@@ -243,8 +240,7 @@ public class UdpClientTest {
     }
 
     private static byte[] createAckPacket(int messageId) throws Exception {
-        UdpRequest ack = new UdpRequest(HaywardMessageType.ACK, "ACK", messageId);
-        return ack.toBytes();
+        return UdpMessage.encodeRequest(HaywardMessageType.ACK, "ACK", messageId);
     }
 
     private static byte[] createLeadPacket(int messageId, int blocks, boolean compressed) {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessageDecodeTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessageDecodeTest.java
@@ -23,10 +23,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link UdpResponse}.
+ * Tests for {@link UdpMessage} response decoding.
  */
 @NonNullByDefault
-public class UdpResponseTest {
+public class UdpMessageDecodeTest {
 
     private static final String RESPONSE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><STATUS version=\"1.8\"></STATUS>";
 
@@ -50,8 +50,8 @@ public class UdpResponseTest {
         buffer.put(new byte[3]);
         buffer.put(compressed);
 
-        UdpResponse response = UdpResponse.fromBytes(buffer.array(), buffer.array().length);
-        assertEquals(messageType, response.getMessageType());
+        UdpMessage response = UdpMessage.decodeResponse(buffer.array(), buffer.array().length);
+        assertEquals(messageType, response.getMessageType().getMsgInt());
         assertEquals(messageId, response.getMessageId());
         assertEquals(RESPONSE_XML, response.getXml());
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessageTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessageTest.java
@@ -22,19 +22,17 @@ import org.junit.jupiter.api.Test;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 
 /**
- * Tests for {@link UdpRequest}.
+ * Tests for {@link UdpMessage} request encoding.
  */
 @NonNullByDefault
-public class UdpRequestTest {
+public class UdpMessageTest {
 
     private static final String REQUEST_XML = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request xmlns=\"http://nextgen.hayward.com/api\"><Name>RequestTelemetryData</Name></Request>";
 
     @Test
     public void toBytesShouldCreateHeaderAndPayload() throws Exception {
         HaywardMessageType messageType = HaywardMessageType.MSP_TELEMETRY_UPDATE;
-        UdpRequest request = new UdpRequest(messageType, REQUEST_XML);
-
-        byte[] bytes = request.toBytes();
+        byte[] bytes = UdpMessage.encodeRequest(messageType, REQUEST_XML);
 
         byte[] xmlBytes = (REQUEST_XML + '\0').getBytes(StandardCharsets.UTF_8);
         assertEquals(24 + xmlBytes.length, bytes.length);


### PR DESCRIPTION
## Summary
- add `UdpMessage` with helpers for request encoding and response decoding
- deprecate legacy `UdpRequest`/`UdpResponse`
- update client and bridge handler to use `UdpMessage`

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Failed to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c402acd0ec8323b8c51df8323811fe