### PR TITLE
feat: centralize payload compression for OmniLogic UDP messages

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/MessageAssembler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/MessageAssembler.java
@@ -13,11 +13,9 @@
 
 package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.zip.InflaterInputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -80,21 +78,8 @@ public class MessageAssembler {
     public byte[] assemblePayload() throws IOException {
         byte[] payload = blocks.toByteArray();
         if (compressed) {
-            payload = decompress(payload);
+            payload = PayloadCodec.decompress(payload);
         }
         return payload;
-    }
-
-    private static byte[] decompress(byte[] data) throws IOException {
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
-                InflaterInputStream iis = new InflaterInputStream(bais);
-                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            byte[] buffer = new byte[1024];
-            int len;
-            while ((len = iis.read(buffer)) != -1) {
-                baos.write(buffer, 0, len);
-            }
-            return baos.toByteArray();
-        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/PayloadCodec.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/PayloadCodec.java
@@ -1,0 +1,54 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.net;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
+
+/**
+ * Utility for compressing and decompressing message payloads.
+ */
+public final class PayloadCodec {
+
+    private PayloadCodec() {
+        // Utility class
+    }
+
+    /**
+     * Compresses the provided byte array using the deflate algorithm.
+     *
+     * @param data the data to compress
+     * @return the compressed representation
+     * @throws IOException if an error occurs while compressing the data
+     */
+    public static byte[] compress(byte[] data) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DeflaterOutputStream dos = new DeflaterOutputStream(baos)) {
+            dos.write(data);
+            dos.finish();
+            return baos.toByteArray();
+        }
+    }
+
+    /**
+     * Decompresses the provided byte array using the inflate algorithm.
+     *
+     * @param data the data to decompress
+     * @return the decompressed representation
+     * @throws IOException if an error occurs while decompressing the data
+     */
+    public static byte[] decompress(byte[] data) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                InflaterInputStream iis = new InflaterInputStream(bais);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = iis.read(buffer)) != -1) {
+                baos.write(buffer, 0, len);
+            }
+            return baos.toByteArray();
+        }
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessageDecodeTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpMessageDecodeTest.java
@@ -14,10 +14,8 @@ package org.openhab.binding.haywardomnilogiclocal.internal.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.zip.DeflaterOutputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -35,11 +33,7 @@ public class UdpMessageDecodeTest {
         int messageId = 0x01020304;
         int messageType = 1004;
         byte[] xmlBytes = RESPONSE_XML.getBytes(StandardCharsets.UTF_8);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (DeflaterOutputStream deflater = new DeflaterOutputStream(baos)) {
-            deflater.write(xmlBytes);
-        }
-        byte[] compressed = baos.toByteArray();
+        byte[] compressed = PayloadCodec.compress(xmlBytes);
         ByteBuffer buffer = ByteBuffer.allocate(24 + compressed.length);
         buffer.putInt(messageId);
 
@@ -47,7 +41,9 @@ public class UdpMessageDecodeTest {
         buffer.put("1.22".getBytes(StandardCharsets.US_ASCII));
         buffer.putInt(messageType);
         buffer.put((byte) 1);
-        buffer.put(new byte[3]);
+        buffer.put((byte) 0);
+        buffer.put((byte) 1);
+        buffer.put((byte) 0);
         buffer.put(compressed);
 
         UdpMessage response = UdpMessage.decodeResponse(buffer.array(), buffer.array().length);


### PR DESCRIPTION
## Summary
- add reusable PayloadCodec to handle compressing and decompressing payloads
- switch MessageAssembler and UdpMessage to use PayloadCodec and header compression flag
- update tests for compression flag handling

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c405500d608323a82274aa8ee3fab8