### PR TITLE
Handle unknown Hayward message type in UDP header

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpHeader.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/net/UdpHeader.java
@@ -105,7 +105,11 @@ public class UdpHeader {
         byte[] versionBytes = new byte[4];
         buffer.get(versionBytes);
         String ver = new String(versionBytes, StandardCharsets.US_ASCII);
-        HaywardMessageType msgType = HaywardMessageType.fromMsgInt(buffer.getInt());
+        int msgTypeInt = buffer.getInt();
+        HaywardMessageType msgType = HaywardMessageType.fromMsgInt(msgTypeInt);
+        if (msgType == null) {
+            throw new IllegalArgumentException("Unknown message type: " + msgTypeInt);
+        }
         byte client = buffer.get();
         buffer.get(); // reserved
         boolean comp = buffer.get() == 1;


### PR DESCRIPTION
## Summary
- throw IllegalArgumentException when UDP header contains unknown message type

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c42886f0348323a0ccb40499ce477b