### PR TITLE
Use XStream for OmniLogic telemetry parsing

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardColorLogicHandler.java
@@ -6,6 +6,10 @@ import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.ColorLogicLight;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Status;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.TelemetryParser;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -47,5 +51,20 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
 
         putIfPresent(values, "colorMode_" + sysId, getThing().getProperties(), "colorMode");
         updateIfPresent(values, "brightness_" + sysId, "brightness");
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        Status status = TelemetryParser.parse(xmlResponse);
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+        for (ColorLogicLight cl : status.getColorLogicLights()) {
+            if (sysId.equals(cl.getSystemId())) {
+                updateData("colorMode", cl.getCurrentShow());
+                updateData("brightness", cl.getBrightness());
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardFilterHandler.java
@@ -6,6 +6,10 @@ import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Filter;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Status;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.TelemetryParser;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -53,5 +57,22 @@ public class HaywardFilterHandler extends HaywardThingHandler {
         updateIfPresent(values, "filterSpeed_" + sysId, "filterSpeed");
         putIfPresent(values, "filterState_" + sysId, getThing().getProperties(), "filterState");
         updateIfPresent(values, "filterLastSpeed_" + sysId, "filterLastSpeed");
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        Status status = TelemetryParser.parse(xmlResponse);
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+        for (Filter f : status.getFilters()) {
+            if (sysId.equals(f.getSystemId())) {
+                updateData("filterEnable", f.getFilterState());
+                updateData("filterSpeed", f.getFilterSpeed());
+                updateData("filterState", f.getFilterState());
+                updateData("filterLastSpeed", f.getLastSpeed());
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardHeaterHandler.java
@@ -4,6 +4,10 @@ import java.util.Map;
 
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Heater;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Status;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.TelemetryParser;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.core.thing.Thing;
 
 public class HaywardHeaterHandler extends HaywardThingHandler {
@@ -20,5 +24,21 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
 
         updateIfPresent(values, "heaterEnable_" + sysId, "heaterEnable");
         putIfPresent(values, "heaterState_" + sysId, getThing().getProperties(), "heaterState");
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        Status status = TelemetryParser.parse(xmlResponse);
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+        for (Heater h : status.getHeaters()) {
+            if (sysId.equals(h.getSystemId())) {
+                updateData("heaterState", h.getHeaterState());
+                String enable = "yes".equals(h.getEnable()) ? "1" : "0";
+                updateData("heaterEnable", enable);
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardPumpHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardPumpHandler.java
@@ -6,6 +6,10 @@ import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Pump;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Status;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.TelemetryParser;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -53,5 +57,22 @@ public class HaywardPumpHandler extends HaywardThingHandler {
         updateIfPresent(values, "pumpSpeed_" + sysId, "pumpSpeed");
         putIfPresent(values, "pumpState_" + sysId, getThing().getProperties(), "pumpState");
         updateIfPresent(values, "pumpLastSpeed_" + sysId, "pumpLastSpeed");
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        Status status = TelemetryParser.parse(xmlResponse);
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+        for (Pump p : status.getPumps()) {
+            if (sysId.equals(p.getSystemId())) {
+                updateData("pumpEnable", p.getPumpState());
+                updateData("pumpSpeed", p.getPumpSpeed());
+                updateData("pumpState", p.getPumpState());
+                updateData("pumpLastSpeed", p.getLastSpeed());
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardRelayHandler.java
@@ -4,6 +4,10 @@ import java.util.Map;
 
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Relay;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Status;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.TelemetryParser;
 import org.openhab.core.thing.Thing;
 
 public class HaywardRelayHandler extends HaywardThingHandler {
@@ -19,5 +23,19 @@ public class HaywardRelayHandler extends HaywardThingHandler {
         }
 
         updateIfPresent(values, "relayState_" + sysId, "relayState");
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        Status status = TelemetryParser.parse(xmlResponse);
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+        for (Relay r : status.getRelays()) {
+            if (sysId.equals(r.getSystemId())) {
+                updateData("relayState", r.getRelayState());
+            }
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Backyard.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Backyard.java
@@ -1,0 +1,39 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("Backyard")
+public class Backyard {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    private String airTemp;
+
+    @XStreamAsAttribute
+    private String status;
+
+    @XStreamAsAttribute
+    private String state;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getAirTemp() {
+        return airTemp;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getState() {
+        return state;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/BodyOfWater.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/BodyOfWater.java
@@ -1,0 +1,34 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("BodyOfWater")
+public class BodyOfWater {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("waterTemp")
+    private String waterTemp;
+
+    @XStreamAsAttribute
+    @XStreamAlias("flow")
+    private String flow;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getWaterTemp() {
+        return waterTemp;
+    }
+
+    public String getFlow() {
+        return flow;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Chlorinator.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Chlorinator.java
@@ -1,0 +1,66 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("Chlorinator")
+public class Chlorinator {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("status")
+    private String status;
+
+    @XStreamAsAttribute
+    @XStreamAlias("instantSaltLevel")
+    private String instantSaltLevel;
+
+    @XStreamAsAttribute
+    @XStreamAlias("avgSaltLevel")
+    private String avgSaltLevel;
+
+    @XStreamAsAttribute
+    @XStreamAlias("Timed-Percent")
+    private String timedPercent;
+
+    @XStreamAsAttribute
+    @XStreamAlias("operatingMode")
+    private String operatingMode;
+
+    @XStreamAsAttribute
+    @XStreamAlias("operatingState")
+    private String operatingState;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getInstantSaltLevel() {
+        return instantSaltLevel;
+    }
+
+    public String getAvgSaltLevel() {
+        return avgSaltLevel;
+    }
+
+    public String getTimedPercent() {
+        return timedPercent;
+    }
+
+    public String getOperatingMode() {
+        return operatingMode;
+    }
+
+    public String getOperatingState() {
+        return operatingState;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/ColorLogicLight.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/ColorLogicLight.java
@@ -1,0 +1,34 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("ColorLogic-Light")
+public class ColorLogicLight {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("currentShow")
+    private String currentShow;
+
+    @XStreamAsAttribute
+    @XStreamAlias("brightness")
+    private String brightness;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getCurrentShow() {
+        return currentShow;
+    }
+
+    public String getBrightness() {
+        return brightness;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Filter.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Filter.java
@@ -1,0 +1,42 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("Filter")
+public class Filter {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("filterSpeed")
+    private String filterSpeed;
+
+    @XStreamAsAttribute
+    @XStreamAlias("filterState")
+    private String filterState;
+
+    @XStreamAsAttribute
+    @XStreamAlias("lastSpeed")
+    private String lastSpeed;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getFilterSpeed() {
+        return filterSpeed;
+    }
+
+    public String getFilterState() {
+        return filterState;
+    }
+
+    public String getLastSpeed() {
+        return lastSpeed;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Heater.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Heater.java
@@ -1,0 +1,34 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("Heater")
+public class Heater {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("enable")
+    private String enable;
+
+    @XStreamAsAttribute
+    @XStreamAlias("heaterState")
+    private String heaterState;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getEnable() {
+        return enable;
+    }
+
+    public String getHeaterState() {
+        return heaterState;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Pump.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Pump.java
@@ -1,0 +1,42 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("Pump")
+public class Pump {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("pumpSpeed")
+    private String pumpSpeed;
+
+    @XStreamAsAttribute
+    @XStreamAlias("pumpState")
+    private String pumpState;
+
+    @XStreamAsAttribute
+    @XStreamAlias("lastSpeed")
+    private String lastSpeed;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getPumpSpeed() {
+        return pumpSpeed;
+    }
+
+    public String getPumpState() {
+        return pumpState;
+    }
+
+    public String getLastSpeed() {
+        return lastSpeed;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Relay.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Relay.java
@@ -1,0 +1,26 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("Relay")
+public class Relay {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("relayState")
+    private String relayState;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getRelayState() {
+        return relayState;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Status.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Status.java
@@ -1,0 +1,79 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of the STATUS telemetry response from the controller.
+ */
+@NonNullByDefault
+@XStreamAlias("STATUS")
+public class Status {
+    @XStreamImplicit(itemFieldName = "Backyard")
+    private final List<Backyard> backyards = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "ColorLogic-Light")
+    private final List<ColorLogicLight> colorLogicLights = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "BodyOfWater")
+    private final List<BodyOfWater> bodiesOfWater = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Filter")
+    private final List<Filter> filters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "VirtualHeater")
+    private final List<VirtualHeater> virtualHeaters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Heater")
+    private final List<Heater> heaters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Chlorinator")
+    private final List<Chlorinator> chlorinators = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Relay")
+    private final List<Relay> relays = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Pump")
+    private final List<Pump> pumps = new ArrayList<>();
+
+    public List<Backyard> getBackyards() {
+        return backyards;
+    }
+
+    public List<ColorLogicLight> getColorLogicLights() {
+        return colorLogicLights;
+    }
+
+    public List<BodyOfWater> getBodiesOfWater() {
+        return bodiesOfWater;
+    }
+
+    public List<Filter> getFilters() {
+        return filters;
+    }
+
+    public List<VirtualHeater> getVirtualHeaters() {
+        return virtualHeaters;
+    }
+
+    public List<Heater> getHeaters() {
+        return heaters;
+    }
+
+    public List<Chlorinator> getChlorinators() {
+        return chlorinators;
+    }
+
+    public List<Relay> getRelays() {
+        return relays;
+    }
+
+    public List<Pump> getPumps() {
+        return pumps;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/TelemetryParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/TelemetryParser.java
@@ -1,0 +1,28 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+
+/**
+ * Utility for parsing telemetry STATUS messages using XStream.
+ */
+@NonNullByDefault
+public final class TelemetryParser {
+    private static final XStream XSTREAM = new XStream(new StaxDriver());
+
+    static {
+        XSTREAM.ignoreUnknownElements();
+        XSTREAM.addPermission(AnyTypePermission.ANY);
+        XSTREAM.processAnnotations(Status.class);
+    }
+
+    private TelemetryParser() {
+    }
+
+    public static Status parse(String xml) {
+        return (Status) XSTREAM.fromXML(xml);
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/VirtualHeater.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/VirtualHeater.java
@@ -1,0 +1,34 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("VirtualHeater")
+public class VirtualHeater {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("enable")
+    private String enable;
+
+    @XStreamAsAttribute
+    @XStreamAlias("Current-Set-Point")
+    private String currentSetPoint;
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public String getEnable() {
+        return enable;
+    }
+
+    public String getCurrentSetPoint() {
+        return currentSetPoint;
+    }
+}


### PR DESCRIPTION
## Summary
- add telemetry model and XStream parser
- update thing handlers to parse telemetry XML and refresh channel states

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c575ba2a488323b7df1014efd832b9