### PR TITLE
Handle missing telemetry in Hayward OmniLogic Local binding

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/HaywardThingHandler.java
@@ -132,8 +132,11 @@ public abstract class HaywardThingHandler extends BaseThingHandler {
         }
     }
 
-    public Map<String, State> updateData(String channelID, String data) {
+    public Map<String, State> updateData(String channelID, @Nullable String data) {
         Map<String, State> channelStates = new HashMap<>();
+        if (data == null) {
+            return channelStates;
+        }
         Channel chan = getThing().getChannel(channelID);
         if (chan != null) {
             String acceptedItemType = chan.getAcceptedItemType();

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBackyardHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBackyardHandler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
@@ -50,9 +51,29 @@ public class HaywardBackyardHandler extends HaywardThingHandler {
 
         for (Backyard by : status.getBackyards()) {
             if (sysId.equals(by.getSystemId())) {
-                updateData(HaywardBindingConstants.CHANNEL_BACKYARD_AIRTEMP, by.getAirTemp());
-                updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATUS, by.getStatus());
-                updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATE, by.getState());
+                @Nullable
+                String airTemp = by.getAirTemp();
+                if (airTemp != null) {
+                    updateData(HaywardBindingConstants.CHANNEL_BACKYARD_AIRTEMP, airTemp);
+                } else {
+                    logger.debug("Backyard air temperature missing");
+                }
+
+                @Nullable
+                String byStatus = by.getStatus();
+                if (byStatus != null) {
+                    updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATUS, byStatus);
+                } else {
+                    logger.debug("Backyard status missing");
+                }
+
+                @Nullable
+                String state = by.getState();
+                if (state != null) {
+                    updateData(HaywardBindingConstants.CHANNEL_BACKYARD_STATE, state);
+                } else {
+                    logger.debug("Backyard state missing");
+                }
             }
         }
         updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBowHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBowHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
@@ -40,8 +41,14 @@ public class HaywardBowHandler extends HaywardThingHandler {
         String sysId = getThing().getUID().getId();
         for (BodyOfWater bow : status.getBodiesOfWater()) {
             if (sysId.equals(bow.getSystemId())) {
-                updateData(HaywardBindingConstants.CHANNEL_BOW_FLOW, bow.getFlow());
-                updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, bow.getWaterTemp());
+                @Nullable String flow = bow.getFlow();
+                if (flow != null) {
+                    updateData(HaywardBindingConstants.CHANNEL_BOW_FLOW, flow);
+                }
+                @Nullable String waterTemp = bow.getWaterTemp();
+                if (waterTemp != null) {
+                    updateData(HaywardBindingConstants.CHANNEL_BOW_WATERTEMP, waterTemp);
+                }
             }
         }
         updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardChlorinatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardChlorinatorHandler.java
@@ -2,6 +2,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
@@ -68,12 +69,35 @@ public class HaywardChlorinatorHandler extends HaywardThingHandler {
         }
         for (Chlorinator c : status.getChlorinators()) {
             if (sysId.equals(c.getSystemId())) {
-                updateData("chlorEnable", c.getOperatingState());
-                updateData("chlorOperatingMode", c.getOperatingMode());
-                updateData("chlorSaltOutput", c.getTimedPercent());
-                updateData("chlorAvgSaltLevel", c.getAvgSaltLevel());
-                updateData("chlorInstantSaltLevel", c.getInstantSaltLevel());
-                updateData("chlorStatus", c.getStatus());
+                @Nullable String operatingState = c.getOperatingState();
+                if (operatingState != null) {
+                    updateData("chlorEnable", operatingState);
+                }
+
+                @Nullable String operatingMode = c.getOperatingMode();
+                if (operatingMode != null) {
+                    updateData("chlorOperatingMode", operatingMode);
+                }
+
+                @Nullable String timedPercent = c.getTimedPercent();
+                if (timedPercent != null) {
+                    updateData("chlorSaltOutput", timedPercent);
+                }
+
+                @Nullable String avgSaltLevel = c.getAvgSaltLevel();
+                if (avgSaltLevel != null) {
+                    updateData("chlorAvgSaltLevel", avgSaltLevel);
+                }
+
+                @Nullable String instantSaltLevel = c.getInstantSaltLevel();
+                if (instantSaltLevel != null) {
+                    updateData("chlorInstantSaltLevel", instantSaltLevel);
+                }
+
+                @Nullable String statusVal = c.getStatus();
+                if (statusVal != null) {
+                    updateData("chlorStatus", statusVal);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardColorLogicHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardColorLogicHandler.java
@@ -2,6 +2,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
@@ -62,8 +63,14 @@ public class HaywardColorLogicHandler extends HaywardThingHandler {
         }
         for (ColorLogicLight cl : status.getColorLogicLights()) {
             if (sysId.equals(cl.getSystemId())) {
-                updateData("colorMode", cl.getCurrentShow());
-                updateData("brightness", cl.getBrightness());
+                @Nullable String currentShow = cl.getCurrentShow();
+                if (currentShow != null) {
+                    updateData("colorMode", currentShow);
+                }
+                @Nullable String brightness = cl.getBrightness();
+                if (brightness != null) {
+                    updateData("brightness", brightness);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardFilterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardFilterHandler.java
@@ -2,6 +2,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
@@ -68,10 +69,21 @@ public class HaywardFilterHandler extends HaywardThingHandler {
         }
         for (Filter f : status.getFilters()) {
             if (sysId.equals(f.getSystemId())) {
-                updateData("filterEnable", f.getFilterState());
-                updateData("filterSpeed", f.getFilterSpeed());
-                updateData("filterState", f.getFilterState());
-                updateData("filterLastSpeed", f.getLastSpeed());
+                @Nullable String filterState = f.getFilterState();
+                if (filterState != null) {
+                    updateData("filterEnable", filterState);
+                    updateData("filterState", filterState);
+                }
+
+                @Nullable String filterSpeed = f.getFilterSpeed();
+                if (filterSpeed != null) {
+                    updateData("filterSpeed", filterSpeed);
+                }
+
+                @Nullable String lastSpeed = f.getLastSpeed();
+                if (lastSpeed != null) {
+                    updateData("filterLastSpeed", lastSpeed);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardHeaterHandler.java
@@ -2,6 +2,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
 import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Heater;
@@ -35,9 +36,15 @@ public class HaywardHeaterHandler extends HaywardThingHandler {
         }
         for (Heater h : status.getHeaters()) {
             if (sysId.equals(h.getSystemId())) {
-                updateData("heaterState", h.getHeaterState());
-                String enable = "yes".equals(h.getEnable()) ? "1" : "0";
-                updateData("heaterEnable", enable);
+                @Nullable String heaterState = h.getHeaterState();
+                if (heaterState != null) {
+                    updateData("heaterState", heaterState);
+                }
+                @Nullable String enableStr = h.getEnable();
+                if (enableStr != null) {
+                    String enable = "yes".equals(enableStr) ? "1" : "0";
+                    updateData("heaterEnable", enable);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardPumpHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardPumpHandler.java
@@ -2,6 +2,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.net.CommandBuilder;
@@ -68,10 +69,21 @@ public class HaywardPumpHandler extends HaywardThingHandler {
         }
         for (Pump p : status.getPumps()) {
             if (sysId.equals(p.getSystemId())) {
-                updateData("pumpEnable", p.getPumpState());
-                updateData("pumpSpeed", p.getPumpSpeed());
-                updateData("pumpState", p.getPumpState());
-                updateData("pumpLastSpeed", p.getLastSpeed());
+                @Nullable String pumpState = p.getPumpState();
+                if (pumpState != null) {
+                    updateData("pumpEnable", pumpState);
+                    updateData("pumpState", pumpState);
+                }
+
+                @Nullable String pumpSpeed = p.getPumpSpeed();
+                if (pumpSpeed != null) {
+                    updateData("pumpSpeed", pumpSpeed);
+                }
+
+                @Nullable String lastSpeed = p.getLastSpeed();
+                if (lastSpeed != null) {
+                    updateData("pumpLastSpeed", lastSpeed);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardRelayHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardRelayHandler.java
@@ -2,6 +2,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
 import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
@@ -34,7 +35,10 @@ public class HaywardRelayHandler extends HaywardThingHandler {
         }
         for (Relay r : status.getRelays()) {
             if (sysId.equals(r.getSystemId())) {
-                updateData("relayState", r.getRelayState());
+                @Nullable String relayState = r.getRelayState();
+                if (relayState != null) {
+                    updateData("relayState", relayState);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardVirtualHeaterHandler.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
@@ -85,9 +86,20 @@ public class HaywardVirtualHeaterHandler extends HaywardThingHandler {
         String sysId = getThing().getUID().getId();
         for (VirtualHeater vh : status.getVirtualHeaters()) {
             if (sysId.equals(vh.getSystemId())) {
-                updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT, vh.getCurrentSetPoint());
-                String enable = "yes".equals(vh.getEnable()) ? "1" : "0";
-                updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, enable);
+                @Nullable String setPoint = vh.getCurrentSetPoint();
+                if (setPoint != null) {
+                    updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_CURRENTSETPOINT, setPoint);
+                } else {
+                    logger.debug("Virtual heater set point missing");
+                }
+
+                @Nullable String enableStr = vh.getEnable();
+                if (enableStr != null) {
+                    String enable = "yes".equals(enableStr) ? "1" : "0";
+                    updateData(HaywardBindingConstants.CHANNEL_VIRTUALHEATER_ENABLE, enable);
+                } else {
+                    logger.debug("Virtual heater enable missing");
+                }
             }
         }
         updateStatus(ThingStatus.ONLINE);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Backyard.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Backyard.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,30 +11,30 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class Backyard {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
-    private String airTemp;
+    private @Nullable String airTemp;
 
     @XStreamAsAttribute
-    private String status;
+    private @Nullable String status;
 
     @XStreamAsAttribute
-    private String state;
+    private @Nullable String state;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getAirTemp() {
+    public @Nullable String getAirTemp() {
         return airTemp;
     }
 
-    public String getStatus() {
+    public @Nullable String getStatus() {
         return status;
     }
 
-    public String getState() {
+    public @Nullable String getState() {
         return state;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/BodyOfWater.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/BodyOfWater.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,25 +11,25 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class BodyOfWater {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("waterTemp")
-    private String waterTemp;
+    private @Nullable String waterTemp;
 
     @XStreamAsAttribute
     @XStreamAlias("flow")
-    private String flow;
+    private @Nullable String flow;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getWaterTemp() {
+    public @Nullable String getWaterTemp() {
         return waterTemp;
     }
 
-    public String getFlow() {
+    public @Nullable String getFlow() {
         return flow;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Chlorinator.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Chlorinator.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,57 +11,57 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class Chlorinator {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("status")
-    private String status;
+    private @Nullable String status;
 
     @XStreamAsAttribute
     @XStreamAlias("instantSaltLevel")
-    private String instantSaltLevel;
+    private @Nullable String instantSaltLevel;
 
     @XStreamAsAttribute
     @XStreamAlias("avgSaltLevel")
-    private String avgSaltLevel;
+    private @Nullable String avgSaltLevel;
 
     @XStreamAsAttribute
     @XStreamAlias("Timed-Percent")
-    private String timedPercent;
+    private @Nullable String timedPercent;
 
     @XStreamAsAttribute
     @XStreamAlias("operatingMode")
-    private String operatingMode;
+    private @Nullable String operatingMode;
 
     @XStreamAsAttribute
     @XStreamAlias("operatingState")
-    private String operatingState;
+    private @Nullable String operatingState;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getStatus() {
+    public @Nullable String getStatus() {
         return status;
     }
 
-    public String getInstantSaltLevel() {
+    public @Nullable String getInstantSaltLevel() {
         return instantSaltLevel;
     }
 
-    public String getAvgSaltLevel() {
+    public @Nullable String getAvgSaltLevel() {
         return avgSaltLevel;
     }
 
-    public String getTimedPercent() {
+    public @Nullable String getTimedPercent() {
         return timedPercent;
     }
 
-    public String getOperatingMode() {
+    public @Nullable String getOperatingMode() {
         return operatingMode;
     }
 
-    public String getOperatingState() {
+    public @Nullable String getOperatingState() {
         return operatingState;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/ColorLogicLight.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/ColorLogicLight.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,25 +11,25 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class ColorLogicLight {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("currentShow")
-    private String currentShow;
+    private @Nullable String currentShow;
 
     @XStreamAsAttribute
     @XStreamAlias("brightness")
-    private String brightness;
+    private @Nullable String brightness;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getCurrentShow() {
+    public @Nullable String getCurrentShow() {
         return currentShow;
     }
 
-    public String getBrightness() {
+    public @Nullable String getBrightness() {
         return brightness;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Filter.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Filter.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,33 +11,33 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class Filter {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("filterSpeed")
-    private String filterSpeed;
+    private @Nullable String filterSpeed;
 
     @XStreamAsAttribute
     @XStreamAlias("filterState")
-    private String filterState;
+    private @Nullable String filterState;
 
     @XStreamAsAttribute
     @XStreamAlias("lastSpeed")
-    private String lastSpeed;
+    private @Nullable String lastSpeed;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getFilterSpeed() {
+    public @Nullable String getFilterSpeed() {
         return filterSpeed;
     }
 
-    public String getFilterState() {
+    public @Nullable String getFilterState() {
         return filterState;
     }
 
-    public String getLastSpeed() {
+    public @Nullable String getLastSpeed() {
         return lastSpeed;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Heater.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Heater.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,25 +11,25 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class Heater {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("enable")
-    private String enable;
+    private @Nullable String enable;
 
     @XStreamAsAttribute
     @XStreamAlias("heaterState")
-    private String heaterState;
+    private @Nullable String heaterState;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getEnable() {
+    public @Nullable String getEnable() {
         return enable;
     }
 
-    public String getHeaterState() {
+    public @Nullable String getHeaterState() {
         return heaterState;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Pump.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Pump.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,33 +11,33 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class Pump {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("pumpSpeed")
-    private String pumpSpeed;
+    private @Nullable String pumpSpeed;
 
     @XStreamAsAttribute
     @XStreamAlias("pumpState")
-    private String pumpState;
+    private @Nullable String pumpState;
 
     @XStreamAsAttribute
     @XStreamAlias("lastSpeed")
-    private String lastSpeed;
+    private @Nullable String lastSpeed;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getPumpSpeed() {
+    public @Nullable String getPumpSpeed() {
         return pumpSpeed;
     }
 
-    public String getPumpState() {
+    public @Nullable String getPumpState() {
         return pumpState;
     }
 
-    public String getLastSpeed() {
+    public @Nullable String getLastSpeed() {
         return lastSpeed;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Relay.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Relay.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,17 +11,17 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class Relay {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("relayState")
-    private String relayState;
+    private @Nullable String relayState;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getRelayState() {
+    public @Nullable String getRelayState() {
         return relayState;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/VirtualHeater.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/VirtualHeater.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -10,25 +11,25 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 public class VirtualHeater {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
-    private String systemId;
+    private @Nullable String systemId;
 
     @XStreamAsAttribute
     @XStreamAlias("enable")
-    private String enable;
+    private @Nullable String enable;
 
     @XStreamAsAttribute
     @XStreamAlias("Current-Set-Point")
-    private String currentSetPoint;
+    private @Nullable String currentSetPoint;
 
-    public String getSystemId() {
+    public @Nullable String getSystemId() {
         return systemId;
     }
 
-    public String getEnable() {
+    public @Nullable String getEnable() {
         return enable;
     }
 
-    public String getCurrentSetPoint() {
+    public @Nullable String getCurrentSetPoint() {
         return currentSetPoint;
     }
 }


### PR DESCRIPTION
## Summary
- mark XStream-loaded telemetry fields as `@Nullable`
- guard handler updates against null telemetry values
- let `updateData` skip null data to prevent runtime exceptions

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: wget: Failed to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b273966c8323a27fbb2fd7135dbb