### PR TITLE
Implement MSP configuration retrieval and tests

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandler.java
@@ -161,7 +161,21 @@ public class HaywardBridgeHandler extends BaseBridgeHandler {
     }
 
     public String getMspConfig() throws HaywardException, InterruptedException {
-        return "ToDo";
+        String xmlRequest =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request xmlns=\"http://nextgen.hayward.com/api\"><Name>RequestConfiguration</Name></Request>";
+        String xmlResponse = sendRequest(xmlRequest, HaywardMessageType.REQUEST_CONFIGURATION);
+
+        if (xmlResponse.isEmpty()) {
+            logger.error("Hayward Connection thing: getMspConfig XML response was null");
+            throw new HaywardException("MSP configuration response empty");
+        }
+
+        if (!evaluateXPath("/Response/Parameters//Parameter[@name='StatusMessage']/text()", xmlResponse).isEmpty()) {
+            logger.error("Hayward Connection thing: getMspConfig XML response: {}", xmlResponse);
+            throw new HaywardException("MSP configuration response contains status message");
+        }
+
+        return xmlResponse;
     }
 
     public synchronized boolean requestConfiguration() throws HaywardException {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandlerTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardBridgeHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogiclocal.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardMessageType;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardDynamicStateDescriptionProvider;
+import org.openhab.core.thing.Bridge;
+
+/**
+ * Tests for {@link HaywardBridgeHandler#getMspConfig()}.
+ */
+@NonNullByDefault
+public class HaywardBridgeHandlerTest {
+
+    @Test
+    public void getMspConfigReturnsXml() throws Exception {
+        HaywardDynamicStateDescriptionProvider provider = mock(HaywardDynamicStateDescriptionProvider.class);
+        Bridge bridge = mock(Bridge.class);
+        HaywardBridgeHandler handler = spy(new HaywardBridgeHandler(provider, bridge));
+
+        String xmlResponse =
+                "<Response><Parameters><Parameter name=\"Config\">Value</Parameter></Parameters></Response>";
+        doReturn(xmlResponse).when(handler).sendRequest(anyString(),
+                eq(HaywardMessageType.REQUEST_CONFIGURATION));
+
+        String result = handler.getMspConfig();
+
+        assertEquals(xmlResponse, result);
+        verify(handler).sendRequest(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><Request xmlns=\"http://nextgen.hayward.com/api\"><Name>RequestConfiguration</Name></Request>",
+                HaywardMessageType.REQUEST_CONFIGURATION);
+    }
+
+    @Test
+    public void getMspConfigThrowsOnEmptyResponse() throws Exception {
+        HaywardDynamicStateDescriptionProvider provider = mock(HaywardDynamicStateDescriptionProvider.class);
+        Bridge bridge = mock(Bridge.class);
+        HaywardBridgeHandler handler = spy(new HaywardBridgeHandler(provider, bridge));
+
+        doReturn("").when(handler).sendRequest(anyString(), eq(HaywardMessageType.REQUEST_CONFIGURATION));
+
+        assertThrows(HaywardException.class, () -> handler.getMspConfig());
+    }
+
+    @Test
+    public void getMspConfigThrowsOnStatusMessage() throws Exception {
+        HaywardDynamicStateDescriptionProvider provider = mock(HaywardDynamicStateDescriptionProvider.class);
+        Bridge bridge = mock(Bridge.class);
+        HaywardBridgeHandler handler = spy(new HaywardBridgeHandler(provider, bridge));
+
+        String xmlResponse =
+                "<Response><Parameters><Parameter name=\"StatusMessage\">error</Parameter></Parameters></Response>";
+        doReturn(xmlResponse).when(handler).sendRequest(anyString(),
+                eq(HaywardMessageType.REQUEST_CONFIGURATION));
+
+        assertThrows(HaywardException.class, () -> handler.getMspConfig());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `getMspConfig` to send RequestConfiguration and validate response
- add unit tests covering success and failure scenarios

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*


------
https://chatgpt.com/codex/tasks/task_e_68c5f8714adc8323adbca41d755717c6