### PR TITLE
Add MSP configuration parser for Hayward OmniLogic local binding

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BackyardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BackyardConfig.java
@@ -1,0 +1,83 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of the Backyard element within the MSP configuration.
+ */
+@NonNullByDefault
+@XStreamAlias("Backyard")
+public class BackyardConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamImplicit(itemFieldName = "BodyOfWater")
+    private final List<BodyOfWaterConfig> bodiesOfWater = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Pump")
+    private final List<PumpConfig> pumps = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Filter")
+    private final List<FilterConfig> filters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Heater")
+    private final List<HeaterConfig> heaters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "VirtualHeater")
+    private final List<VirtualHeaterConfig> virtualHeaters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Chlorinator")
+    private final List<ChlorinatorConfig> chlorinators = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "ColorLogic-Light")
+    private final List<ColorLogicLightConfig> colorLogicLights = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Relay")
+    private final List<RelayConfig> relays = new ArrayList<>();
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public List<BodyOfWaterConfig> getBodiesOfWater() {
+        return bodiesOfWater;
+    }
+
+    public List<PumpConfig> getPumps() {
+        return pumps;
+    }
+
+    public List<FilterConfig> getFilters() {
+        return filters;
+    }
+
+    public List<HeaterConfig> getHeaters() {
+        return heaters;
+    }
+
+    public List<VirtualHeaterConfig> getVirtualHeaters() {
+        return virtualHeaters;
+    }
+
+    public List<ChlorinatorConfig> getChlorinators() {
+        return chlorinators;
+    }
+
+    public List<ColorLogicLightConfig> getColorLogicLights() {
+        return colorLogicLights;
+    }
+
+    public List<RelayConfig> getRelays() {
+        return relays;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BodyOfWaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BodyOfWaterConfig.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a BodyOfWater element.
+ */
+@NonNullByDefault
+@XStreamAlias("BodyOfWater")
+public class BodyOfWaterConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ChlorinatorConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ChlorinatorConfig.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a Chlorinator element.
+ */
+@NonNullByDefault
+@XStreamAlias("Chlorinator")
+public class ChlorinatorConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ColorLogicLightConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ColorLogicLightConfig.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a ColorLogic light element.
+ */
+@NonNullByDefault
+@XStreamAlias("ColorLogic-Light")
+public class ColorLogicLightConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
@@ -1,0 +1,29 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+
+/**
+ * Utility for parsing MSP configuration XML using XStream.
+ */
+@NonNullByDefault
+public final class ConfigParser {
+    private static final XStream XSTREAM = new XStream(new StaxDriver());
+
+    static {
+        XSTREAM.ignoreUnknownElements();
+        XSTREAM.addPermission(AnyTypePermission.ANY);
+        XSTREAM.processAnnotations(MspConfig.class);
+    }
+
+    private ConfigParser() {
+    }
+
+    public static MspConfig parse(String xml) {
+        return (MspConfig) XSTREAM.fromXML(xml);
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/FilterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/FilterConfig.java
@@ -1,0 +1,31 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a Filter element.
+ */
+@NonNullByDefault
+@XStreamAlias("Filter")
+public class FilterConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("pumpId")
+    private @Nullable String pumpId;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public @Nullable String getPumpId() {
+        return pumpId;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HeaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HeaterConfig.java
@@ -1,0 +1,30 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a Heater element.
+ */
+@NonNullByDefault
+@XStreamAlias("Heater")
+public class HeaterConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAsAttribute
+    private @Nullable String type;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public @Nullable String getType() {
+        return type;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/MspConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/MspConfig.java
@@ -1,0 +1,24 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of the MSP configuration root element.
+ */
+@NonNullByDefault
+@XStreamAlias("MspConfig")
+public class MspConfig {
+    @XStreamImplicit(itemFieldName = "System")
+    private final List<SystemConfig> systems = new ArrayList<>();
+
+    public List<SystemConfig> getSystems() {
+        return systems;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/PumpConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/PumpConfig.java
@@ -1,0 +1,30 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a Pump element.
+ */
+@NonNullByDefault
+@XStreamAlias("Pump")
+public class PumpConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public @Nullable String getName() {
+        return name;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/RelayConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/RelayConfig.java
@@ -1,0 +1,30 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a Relay element.
+ */
+@NonNullByDefault
+@XStreamAlias("Relay")
+public class RelayConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public @Nullable String getName() {
+        return name;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SystemConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SystemConfig.java
@@ -1,0 +1,34 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of the System element within the MSP configuration.
+ */
+@NonNullByDefault
+@XStreamAlias("System")
+public class SystemConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamImplicit(itemFieldName = "Backyard")
+    private final List<BackyardConfig> backyards = new ArrayList<>();
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public List<BackyardConfig> getBackyards() {
+        return backyards;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/VirtualHeaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/VirtualHeaterConfig.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a VirtualHeater element.
+ */
+@NonNullByDefault
+@XStreamAlias("VirtualHeater")
+public class VirtualHeaterConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -1,0 +1,71 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link ConfigParser}.
+ */
+public class ConfigParserTest {
+    @Test
+    public void testParsePopulatesAllListsAndAttributes() {
+        String xml = "" +
+                "<MspConfig>" +
+                "  <System systemId='SYS'>" +
+                "    <Backyard systemId='BY'>" +
+                "      <BodyOfWater systemId='BOW'/>" +
+                "      <Pump systemId='P1' name='Main'/>" +
+                "      <Filter systemId='F1' pumpId='P1'/>" +
+                "      <Heater systemId='H1' type='gas'/>" +
+                "      <VirtualHeater systemId='VH1'/>" +
+                "      <Chlorinator systemId='C1'/>" +
+                "      <ColorLogic-Light systemId='L1'/>" +
+                "      <Relay systemId='R1' name='Aux1'/>" +
+                "    </Backyard>" +
+                "  </System>" +
+                "</MspConfig>";
+
+        MspConfig config = ConfigParser.parse(xml);
+        assertEquals(1, config.getSystems().size());
+
+        SystemConfig system = config.getSystems().get(0);
+        assertEquals("SYS", system.getSystemId());
+        assertEquals(1, system.getBackyards().size());
+
+        BackyardConfig backyard = system.getBackyards().get(0);
+        assertEquals("BY", backyard.getSystemId());
+        assertEquals(1, backyard.getBodiesOfWater().size());
+        assertEquals("BOW", backyard.getBodiesOfWater().get(0).getSystemId());
+
+        assertEquals(1, backyard.getPumps().size());
+        PumpConfig pump = backyard.getPumps().get(0);
+        assertEquals("P1", pump.getSystemId());
+        assertEquals("Main", pump.getName());
+
+        assertEquals(1, backyard.getFilters().size());
+        FilterConfig filter = backyard.getFilters().get(0);
+        assertEquals("F1", filter.getSystemId());
+        assertEquals("P1", filter.getPumpId());
+
+        assertEquals(1, backyard.getHeaters().size());
+        HeaterConfig heater = backyard.getHeaters().get(0);
+        assertEquals("H1", heater.getSystemId());
+        assertEquals("gas", heater.getType());
+
+        assertEquals(1, backyard.getVirtualHeaters().size());
+        assertEquals("VH1", backyard.getVirtualHeaters().get(0).getSystemId());
+
+        assertEquals(1, backyard.getChlorinators().size());
+        assertEquals("C1", backyard.getChlorinators().get(0).getSystemId());
+
+        assertEquals(1, backyard.getColorLogicLights().size());
+        assertEquals("L1", backyard.getColorLogicLights().get(0).getSystemId());
+
+        assertEquals(1, backyard.getRelays().size());
+        RelayConfig relay = backyard.getRelays().get(0);
+        assertEquals("R1", relay.getSystemId());
+        assertEquals("Aux1", relay.getName());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement MSP configuration model classes using XStream
- add ConfigParser utility to parse MspConfig XML
- add unit test to validate parsing of configuration snippets

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c639bb32f48323be074c5299404193