### PR TITLE
fix: set class loader for hayward telemetry parser

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/TelemetryParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/TelemetryParser.java
@@ -16,6 +16,7 @@ public final class TelemetryParser {
     static {
         XSTREAM.ignoreUnknownElements();
         XSTREAM.addPermission(AnyTypePermission.ANY);
+        XSTREAM.setClassLoader(TelemetryParser.class.getClassLoader());
         XSTREAM.processAnnotations(Status.class);
     }
 


### PR DESCRIPTION
## Summary
- ensure TelemetryParser uses its own class loader so XStream resolves classes

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bd68e0648323a1f9d820d2aa6ffe