### PR TITLE
fix(haywardomnilogiclocal): set XStream class loader

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
@@ -14,6 +14,7 @@ public final class ConfigParser {
     private static final XStream XSTREAM = new XStream(new StaxDriver());
 
     static {
+        XSTREAM.setClassLoader(ConfigParser.class.getClassLoader());
         XSTREAM.ignoreUnknownElements();
         XSTREAM.addPermission(AnyTypePermission.ANY);
         XSTREAM.processAnnotations(MspConfig.class);


### PR DESCRIPTION
## Summary
- ensure ConfigParser uses its class loader when initializing XStream

## Testing
- `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c52ff9108323b9937553a9542193