### PR TITLE
fix: ensure pump name defaults

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
@@ -102,9 +102,11 @@ public class HaywardDiscoveryService extends AbstractThingHandlerDiscoveryServic
                     if (pumpId != null) {
                         pumpProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, pumpId);
                     }
-                    String label = pump.getName();
-                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_PUMP, label != null ? label : pumpId,
-                            pumpProps);
+                    String name = pump.getName() != null ? pump.getName() : pumpId;
+                    if (name == null) {
+                        name = "Pump";
+                    }
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_PUMP, name, pumpProps);
                 }
 
                 for (FilterConfig filter : backyard.getFilters()) {


### PR DESCRIPTION
## Summary
- ensure pump discovery uses a fallback name

## Testing
- `mvn -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c83843488323a6ce5cad5caeb0ca