### PR TITLE
Ensure relay discovery uses non-null name

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
@@ -161,9 +161,11 @@ public class HaywardDiscoveryService extends AbstractThingHandlerDiscoveryServic
                     if (id != null) {
                         relayProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
                     }
-                    String label = relay.getName();
-                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_RELAY, label != null ? label : id,
-                            relayProps);
+                    String name = relay.getName();
+                    if (name == null) {
+                        name = id != null ? id : "Relay";
+                    }
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_RELAY, name, relayProps);
                 }
 
                 for (VirtualHeaterConfig vh : backyard.getVirtualHeaters()) {


### PR DESCRIPTION
## Summary
- Guarantee relay devices provide a non-null name during discovery, defaulting to the system ID or "Relay" when necessary.

## Testing
- `mvn -q -pl :org.openhab.binding.haywardomnilogiclocal -am verify` *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c83b96388323ae66c6f668450b8c