### PR TITLE
Handle null heater type during discovery

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
@@ -125,8 +125,9 @@ public class HaywardDiscoveryService extends AbstractThingHandlerDiscoveryServic
                     if (heaterId != null) {
                         heaterProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, heaterId);
                     }
-                    if (heater.getType() != null) {
-                        heaterProps.put(HaywardBindingConstants.PROPERTY_HEATER_TYPE, heater.getType());
+                    String type = heater.getType();
+                    if (type != null) {
+                        heaterProps.put(HaywardBindingConstants.PROPERTY_HEATER_TYPE, type);
                     }
                     onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_HEATER,
                             heaterId != null ? heaterId : "Heater", heaterProps);


### PR DESCRIPTION
## Summary
- Safely handle heater type property during discovery

## Testing
- ⚠️ `./mvnw -q -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(failed: wget failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c83d650c832399f27e2e25666cfe