### PR TITLE
Add valve actuator telemetry and handler

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardValveActuatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/handler/HaywardValveActuatorHandler.java
@@ -1,0 +1,45 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.handler;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
+import org.openhab.binding.haywardomnilogiclocal.internal.HaywardThingHandler;
+import org.openhab.binding.haywardomnilogiclocal.internal.protocol.ParameterValue;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.Status;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.TelemetryParser;
+import org.openhab.binding.haywardomnilogiclocal.internal.telemetry.ValveActuator;
+import org.openhab.core.thing.Thing;
+
+public class HaywardValveActuatorHandler extends HaywardThingHandler {
+
+    public HaywardValveActuatorHandler(Thing thing) {
+        super(thing);
+    }
+
+    public void updateFromConfig(Map<String, ParameterValue> values) {
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+
+        updateIfPresent(values, "valveActuatorState_" + sysId, "valveActuatorState");
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        Status status = TelemetryParser.parse(xmlResponse);
+        String sysId = getThing().getProperties().get("systemID");
+        if (sysId == null) {
+            return;
+        }
+        for (ValveActuator valveActuator : status.getValveActuators()) {
+            if (sysId.equals(valveActuator.getSystemId())) {
+                @Nullable String valveActuatorState = valveActuator.getValveActuatorState();
+                if (valveActuatorState != null) {
+                    updateData("valveActuatorState", valveActuatorState);
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Status.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/Status.java
@@ -38,6 +38,9 @@ public class Status {
     @XStreamImplicit(itemFieldName = "Relay")
     private final List<Relay> relays = new ArrayList<>();
 
+    @XStreamImplicit(itemFieldName = "ValveActuator")
+    private final List<ValveActuator> valveActuators = new ArrayList<>();
+
     @XStreamImplicit(itemFieldName = "Pump")
     private final List<Pump> pumps = new ArrayList<>();
 
@@ -71,6 +74,10 @@ public class Status {
 
     public List<Relay> getRelays() {
         return relays;
+    }
+
+    public List<ValveActuator> getValveActuators() {
+        return valveActuators;
     }
 
     public List<Pump> getPumps() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/TelemetryParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/TelemetryParser.java
@@ -18,6 +18,7 @@ public final class TelemetryParser {
         XSTREAM.addPermission(AnyTypePermission.ANY);
         XSTREAM.setClassLoader(TelemetryParser.class.getClassLoader());
         XSTREAM.processAnnotations(Status.class);
+        XSTREAM.processAnnotations(ValveActuator.class);
     }
 
     private TelemetryParser() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/ValveActuator.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/telemetry/ValveActuator.java
@@ -1,0 +1,27 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.telemetry;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+@NonNullByDefault
+@XStreamAlias("ValveActuator")
+public class ValveActuator {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAsAttribute
+    @XStreamAlias("valveActuatorState")
+    private @Nullable String valveActuatorState;
+
+    public @Nullable String getSystemId() {
+        return systemId;
+    }
+
+    public @Nullable String getValveActuatorState() {
+        return valveActuatorState;
+    }
+}


### PR DESCRIPTION
## Summary
- add a ValveActuator telemetry DTO mirroring relays
- extend the STATUS telemetry model to expose valve actuators and register it with the parser
- add a handler that updates valve actuator channel data from config or telemetry

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test *(fails: cannot resolve parent POM without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68c862db454083239e0d46c74a119323