### PR TITLE
Add valve actuator support to Hayward OmniLogic binding

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardBindingConstants.java
@@ -38,6 +38,7 @@ public class HaywardBindingConstants {
     public static final ThingTypeUID THING_TYPE_HEATER = new ThingTypeUID(BINDING_ID, "heater");
     public static final ThingTypeUID THING_TYPE_PUMP = new ThingTypeUID(BINDING_ID, "pump");
     public static final ThingTypeUID THING_TYPE_RELAY = new ThingTypeUID(BINDING_ID, "relay");
+    public static final ThingTypeUID THING_TYPE_VALVEACTUATOR = new ThingTypeUID(BINDING_ID, "valveActuator");
     public static final ThingTypeUID THING_TYPE_SENSOR = new ThingTypeUID(BINDING_ID, "sensor");
     public static final ThingTypeUID THING_TYPE_VIRTUALHEATER = new ThingTypeUID(BINDING_ID, "virtualHeater");
 
@@ -48,7 +49,8 @@ public class HaywardBindingConstants {
             HaywardBindingConstants.THING_TYPE_CHLORINATOR, HaywardBindingConstants.THING_TYPE_COLORLOGIC,
             HaywardBindingConstants.THING_TYPE_FILTER, HaywardBindingConstants.THING_TYPE_HEATER,
             HaywardBindingConstants.THING_TYPE_PUMP, HaywardBindingConstants.THING_TYPE_RELAY,
-            HaywardBindingConstants.THING_TYPE_SENSOR, HaywardBindingConstants.THING_TYPE_VIRTUALHEATER);
+            HaywardBindingConstants.THING_TYPE_SENSOR, HaywardBindingConstants.THING_TYPE_VALVEACTUATOR,
+            HaywardBindingConstants.THING_TYPE_VIRTUALHEATER);
 
     // List of all Channel ids (bridge)
     // No Channels
@@ -153,6 +155,12 @@ public class HaywardBindingConstants {
 
     public static final String PROPERTY_RELAY_TYPE = "relayType";
     public static final String PROPERTY_RELAY_FUNCTION = "relayFunction";
+
+    // List of all Channel ids (valve actuator)
+    public static final String CHANNEL_VALVEACTUATOR_STATE = "valveActuatorState";
+
+    public static final String PROPERTY_VALVEACTUATOR_TYPE = "valveActuatorType";
+    public static final String PROPERTY_VALVEACTUATOR_FUNCTION = "valveActuatorFunction";
 
     // List of all Channel ids (sensor)
     public static final String CHANNEL_SENSOR_DATA = "sensorData";

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/HaywardHandlerFactory.java
@@ -31,6 +31,7 @@ import org.openhab.binding.haywardomnilogic.internal.handler.HaywardFilterHandle
 import org.openhab.binding.haywardomnilogic.internal.handler.HaywardHeaterHandler;
 import org.openhab.binding.haywardomnilogic.internal.handler.HaywardPumpHandler;
 import org.openhab.binding.haywardomnilogic.internal.handler.HaywardRelayHandler;
+import org.openhab.binding.haywardomnilogic.internal.handler.HaywardValveActuatorHandler;
 import org.openhab.binding.haywardomnilogic.internal.handler.HaywardVirtualHeaterHandler;
 import org.openhab.core.io.net.http.HttpClientFactory;
 import org.openhab.core.thing.Bridge;
@@ -104,6 +105,9 @@ public class HaywardHandlerFactory extends BaseThingHandlerFactory {
         }
         if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_RELAY)) {
             return new HaywardRelayHandler(thing);
+        }
+        if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_VALVEACTUATOR)) {
+            return new HaywardValveActuatorHandler(thing);
         }
         if (thingTypeUID.equals(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER)) {
             return new HaywardVirtualHeaterHandler(thing);

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardValveActuatorHandler.java
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/java/org/openhab/binding/haywardomnilogic/internal/handler/HaywardValveActuatorHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.haywardomnilogic.internal.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.haywardomnilogic.internal.HaywardBindingConstants;
+import org.openhab.binding.haywardomnilogic.internal.HaywardException;
+import org.openhab.binding.haywardomnilogic.internal.HaywardThingHandler;
+import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+
+/**
+ * The Valve Actuator Handler
+ *
+ * @author Matt Myers - Initial contribution
+ */
+@NonNullByDefault
+public class HaywardValveActuatorHandler extends HaywardThingHandler {
+
+    public HaywardValveActuatorHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void getTelemetry(String xmlResponse) throws HaywardException {
+        List<String> systemIDs = new ArrayList<>();
+        List<String> data = new ArrayList<>();
+
+        Bridge bridge = getBridge();
+        if (bridge != null && bridge.getHandler() instanceof HaywardBridgeHandler bridgehandler) {
+            systemIDs = bridgehandler.evaluateXPath("//ValveActuator/@systemId", xmlResponse);
+            data = bridgehandler.evaluateXPath("//ValveActuator/@valveActuatorState", xmlResponse);
+            String thingSystemID = getThing().getUID().getId();
+            for (int i = 0; i < systemIDs.size(); i++) {
+                if (systemIDs.get(i).equals(thingSystemID)) {
+                    updateData(HaywardBindingConstants.CHANNEL_VALVEACTUATOR_STATE, data.get(i));
+                }
+            }
+            this.updateStatus(ThingStatus.ONLINE);
+        } else {
+            this.updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_UNINITIALIZED);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/i18n/haywardomnilogic.properties
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/i18n/haywardomnilogic.properties
@@ -15,6 +15,7 @@ thing-type.haywardomnilogic.filter.label = Filter
 thing-type.haywardomnilogic.heater.label = Heater
 thing-type.haywardomnilogic.pump.label = Pump
 thing-type.haywardomnilogic.relay.label = Relay
+thing-type.haywardomnilogic.valveActuator.label = Valve Actuator
 thing-type.haywardomnilogic.virtualHeater.label = Virtual Heater
 
 # thing types config

--- a/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/valveactuator.xml
+++ b/bundles/org.openhab.binding.haywardomnilogic/src/main/resources/OH-INF/thing/valveactuator.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="haywardomnilogic"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+        <thing-type id="valveActuator" listed="false">
+                <supported-bridge-type-refs>
+                        <bridge-type-ref id="bridge"/>
+                </supported-bridge-type-refs>
+
+                <label>Valve Actuator</label>
+                <channels>
+                        <channel id="valveActuatorState" typeId="system.power"/>
+                </channels>
+
+                <properties>
+                        <property name="vendor">Hayward</property>
+                        <property name="valveActuatorType"></property>
+                        <property name="valveActuatorFunction"></property>
+                </properties>
+                <representation-property>systemID</representation-property>
+
+        </thing-type>
+
+</thing:thing-descriptions>


### PR DESCRIPTION
## Summary
- add valve actuator constants for the new thing type, channel and properties
- wire up a valve actuator handler and thing description so the new type can update state
- expose a localized label and register the handler in the factory

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogic -am test *(fails: network unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c86919f1988323a249ddcf48b1390d