### PR TITLE
Fix MSP configuration root alias

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/MspConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/MspConfig.java
@@ -12,7 +12,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * Representation of the MSP configuration root element.
  */
 @NonNullByDefault
-@XStreamAlias("MspConfig")
+@XStreamAlias("MSPConfig")
 public class MspConfig {
     @XStreamImplicit(itemFieldName = "System")
     private final List<SystemConfig> systems = new ArrayList<>();

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -11,7 +11,7 @@ public class ConfigParserTest {
     @Test
     public void testParsePopulatesAllListsAndAttributes() {
         String xml = "" +
-                "<MspConfig>" +
+                "<MSPConfig>" +
                 "  <System systemId='SYS'>" +
                 "    <Backyard systemId='BY'>" +
                 "      <BodyOfWater systemId='BOW'/>" +
@@ -24,7 +24,7 @@ public class ConfigParserTest {
                 "      <Relay systemId='R1' name='Aux1'/>" +
                 "    </Backyard>" +
                 "  </System>" +
-                "</MspConfig>";
+                "</MSPConfig>";
 
         MspConfig config = ConfigParser.parse(xml);
         assertEquals(1, config.getSystems().size());


### PR DESCRIPTION
## Summary
- align the MSP configuration XStream alias with the real-world XML tag name
- update ConfigParserTest to parse MSPConfig documents

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test *(fails: network unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c87db55d408323bac54defda66df30