### PR TITLE
Add schedule and DMT parsing to MSP configuration

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
@@ -17,7 +17,11 @@ public final class ConfigParser {
         XSTREAM.setClassLoader(ConfigParser.class.getClassLoader());
         XSTREAM.ignoreUnknownElements();
         XSTREAM.addPermission(AnyTypePermission.ANY);
-        XSTREAM.processAnnotations(MspConfig.class);
+        XSTREAM.processAnnotations(new Class<?>[] { MspConfig.class, SystemConfig.class, BackyardConfig.class,
+                BodyOfWaterConfig.class, PumpConfig.class, FilterConfig.class, HeaterConfig.class,
+                VirtualHeaterConfig.class, ChlorinatorConfig.class, ColorLogicLightConfig.class, RelayConfig.class,
+                SchedulesConfig.class, ScheduleConfig.class, ScheduleActionConfig.class, DeviceConfig.class,
+                ParameterConfig.class, DmtConfig.class });
     }
 
     private ConfigParser() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/DeviceConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/DeviceConfig.java
@@ -1,0 +1,77 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of a device referenced within schedules or the DMT.
+ */
+@NonNullByDefault
+@XStreamAlias("Device")
+public class DeviceConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String type;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String subType;
+
+    @XStreamAlias("Sub-Type")
+    private @Nullable String subTypeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("parentSystemId")
+    private @Nullable String parentSystemId;
+
+    @XStreamAlias("Parent-System-Id")
+    private @Nullable String parentSystemIdElement;
+
+    @XStreamImplicit(itemFieldName = "Parameter")
+    private final List<ParameterConfig> parameters = new ArrayList<>();
+
+    public @Nullable String getSystemId() {
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getType() {
+        return type != null ? type : typeElement;
+    }
+
+    public @Nullable String getSubType() {
+        return subType != null ? subType : subTypeElement;
+    }
+
+    public @Nullable String getParentSystemId() {
+        return parentSystemId != null ? parentSystemId : parentSystemIdElement;
+    }
+
+    public List<ParameterConfig> getParameters() {
+        return parameters;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/DmtConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/DmtConfig.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of the device mapping table (DMT) within the MSP configuration.
+ */
+@NonNullByDefault
+@XStreamAlias("DMT")
+public class DmtConfig {
+    @XStreamImplicit(itemFieldName = "Device")
+    private final List<DeviceConfig> devices = new ArrayList<>();
+
+    public List<DeviceConfig> getDevices() {
+        return devices;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/MspConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/MspConfig.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
@@ -20,12 +21,33 @@ public class MspConfig {
     @XStreamImplicit(itemFieldName = "Backyard")
     private final List<BackyardConfig> backyards = new ArrayList<>();
 
+    @XStreamAlias("Schedules")
+    private final SchedulesConfig schedules = new SchedulesConfig();
+
+    @XStreamAlias("DMT")
+    private final DmtConfig dmt = new DmtConfig();
+
+    @XStreamAlias("CHECKSUM")
+    private @Nullable String checksum;
+
     public List<SystemConfig> getSystems() {
         return systems;
     }
 
     public List<BackyardConfig> getBackyards() {
         return backyards;
+    }
+
+    public List<ScheduleConfig> getSchedules() {
+        return schedules.getSchedules();
+    }
+
+    public DmtConfig getDmt() {
+        return dmt;
+    }
+
+    public @Nullable String getChecksum() {
+        return checksum;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ParameterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ParameterConfig.java
@@ -1,0 +1,58 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
+
+/**
+ * Representation of a Parameter element within schedules or devices.
+ */
+@NonNullByDefault
+@XStreamAlias("Parameter")
+@XStreamConverter(value = ToAttributedValueConverter.class, strings = "value")
+public class ParameterConfig {
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAsAttribute
+    private @Nullable String dataType;
+
+    @XStreamAsAttribute
+    private @Nullable String units;
+
+    @XStreamAsAttribute
+    private @Nullable String index;
+
+    @XStreamAsAttribute
+    private @Nullable String readOnly;
+
+    private @Nullable String value;
+
+    public @Nullable String getName() {
+        return name;
+    }
+
+    public @Nullable String getDataType() {
+        return dataType;
+    }
+
+    public @Nullable String getUnits() {
+        return units;
+    }
+
+    public @Nullable String getIndex() {
+        return index;
+    }
+
+    public @Nullable String getReadOnly() {
+        return readOnly;
+    }
+
+    public @Nullable String getValue() {
+        return value;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ScheduleActionConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ScheduleActionConfig.java
@@ -1,0 +1,53 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of an action within a schedule.
+ */
+@NonNullByDefault
+@XStreamAlias("Action")
+public class ScheduleActionConfig {
+    @XStreamAsAttribute
+    private @Nullable String type;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamImplicit(itemFieldName = "Device")
+    private final List<DeviceConfig> devices = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Parameter")
+    private final List<ParameterConfig> parameters = new ArrayList<>();
+
+    public @Nullable String getType() {
+        return type != null ? type : typeElement;
+    }
+
+    public @Nullable String getSystemId() {
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public List<DeviceConfig> getDevices() {
+        return devices;
+    }
+
+    public List<ParameterConfig> getParameters() {
+        return parameters;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ScheduleConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ScheduleConfig.java
@@ -1,0 +1,90 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Representation of a single schedule entry.
+ */
+@NonNullByDefault
+@XStreamAlias("Schedule")
+public class ScheduleConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String type;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String subType;
+
+    @XStreamAlias("Sub-Type")
+    private @Nullable String subTypeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String enabled;
+
+    @XStreamAlias("Enabled")
+    private @Nullable String enabledElement;
+
+    @XStreamImplicit(itemFieldName = "Device")
+    private final List<DeviceConfig> devices = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Parameter")
+    private final List<ParameterConfig> parameters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Action")
+    private final List<ScheduleActionConfig> actions = new ArrayList<>();
+
+    public @Nullable String getSystemId() {
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getType() {
+        return type != null ? type : typeElement;
+    }
+
+    public @Nullable String getSubType() {
+        return subType != null ? subType : subTypeElement;
+    }
+
+    public @Nullable String getEnabled() {
+        return enabled != null ? enabled : enabledElement;
+    }
+
+    public List<DeviceConfig> getDevices() {
+        return devices;
+    }
+
+    public List<ParameterConfig> getParameters() {
+        return parameters;
+    }
+
+    public List<ScheduleActionConfig> getActions() {
+        return actions;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SchedulesConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SchedulesConfig.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Container for all schedule elements in the MSP configuration.
+ */
+@NonNullByDefault
+@XStreamAlias("Schedules")
+public class SchedulesConfig {
+    @XStreamImplicit(itemFieldName = "Schedule")
+    private final List<ScheduleConfig> schedules = new ArrayList<>();
+
+    public List<ScheduleConfig> getSchedules() {
+        return schedules;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -23,6 +23,21 @@ public class ConfigParserTest {
                 "    <ColorLogic-Light systemId='L1'/>" +
                 "    <Relay systemId='R1' name='Aux1'/>" +
                 "  </Backyard>" +
+                "  <Schedules>" +
+                "    <Schedule systemId='SCH1' name='Filter' type='equipment'>" +
+                "      <Device systemId='P1' name='Main Pump' type='Pump'/>" +
+                "      <Parameter name='StartTimeHours' dataType='int'>6</Parameter>" +
+                "      <Action type='on'>" +
+                "        <Device systemId='R1' name='Aux1' type='Relay'/>" +
+                "      </Action>" +
+                "    </Schedule>" +
+                "  </Schedules>" +
+                "  <DMT>" +
+                "    <Device systemId='DEV1' name='Filter Pump' type='Pump'>" +
+                "      <Parameter name='Speed' dataType='int'>3450</Parameter>" +
+                "    </Device>" +
+                "  </DMT>" +
+                "  <CHECKSUM>12345</CHECKSUM>" +
                 "</MSPConfig>";
 
         MspConfig config = ConfigParser.parse(xml);
@@ -66,6 +81,35 @@ public class ConfigParserTest {
         RelayConfig relay = backyard.getRelays().get(0);
         assertEquals("R1", relay.getSystemId());
         assertEquals("Aux1", relay.getName());
+
+        assertEquals(1, config.getSchedules().size());
+        ScheduleConfig schedule = config.getSchedules().get(0);
+        assertEquals("SCH1", schedule.getSystemId());
+        assertEquals("Filter", schedule.getName());
+        assertEquals(1, schedule.getDevices().size());
+        DeviceConfig scheduleDevice = schedule.getDevices().get(0);
+        assertEquals("P1", scheduleDevice.getSystemId());
+        assertEquals("Main Pump", scheduleDevice.getName());
+        assertEquals(1, schedule.getParameters().size());
+        ParameterConfig parameter = schedule.getParameters().get(0);
+        assertEquals("StartTimeHours", parameter.getName());
+        assertEquals("6", parameter.getValue());
+        assertEquals(1, schedule.getActions().size());
+        ScheduleActionConfig action = schedule.getActions().get(0);
+        assertEquals("on", action.getType());
+        assertEquals(1, action.getDevices().size());
+        assertEquals("R1", action.getDevices().get(0).getSystemId());
+
+        assertEquals(1, config.getDmt().getDevices().size());
+        DeviceConfig device = config.getDmt().getDevices().get(0);
+        assertEquals("DEV1", device.getSystemId());
+        assertEquals("Filter Pump", device.getName());
+        assertEquals("Pump", device.getType());
+        assertEquals(1, device.getParameters().size());
+        assertEquals("Speed", device.getParameters().get(0).getName());
+        assertEquals("3450", device.getParameters().get(0).getValue());
+
+        assertEquals("12345", config.getChecksum());
     }
 }
 


### PR DESCRIPTION
## Summary
- add XStream DTOs for schedules, DMT, devices, and parameters so the MSP config can be fully deserialized
- expose schedules, DMT, and checksum data from `MspConfig`
- register the new classes in `ConfigParser` and extend the unit test coverage

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test *(fails: unable to resolve parent POM because Maven Central is unreachable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a51dddb48323bd5aabdc9b248baa