### PR TITLE
Add support for system preference fields

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SystemConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SystemConfig.java
@@ -16,8 +16,113 @@ public class SystemConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("Msp-Vsp-Speed-Format")
+    private @Nullable String mspVspSpeedFormat;
+
+    @XStreamAlias("Msp-Time-Format")
+    private @Nullable String mspTimeFormat;
+
+    @XStreamAlias("Time-Zone")
+    private @Nullable String timeZone;
+
+    @XStreamAlias("DST")
+    private @Nullable String dst;
+
+    @XStreamAlias("Internet-Time")
+    private @Nullable String internetTime;
+
+    @XStreamAlias("Units")
+    private @Nullable String units;
+
+    @XStreamAlias("Msp-Chlor-Display")
+    private @Nullable String mspChlorDisplay;
+
+    @XStreamAlias("Msp-Language")
+    private @Nullable String mspLanguage;
+
+    @XStreamAlias("UI-Show-Backyard")
+    private @Nullable String uiShowBackyard;
+
+    @XStreamAlias("UI-Show-Equipment")
+    private @Nullable String uiShowEquipment;
+
+    @XStreamAlias("UI-Show-Heaters")
+    private @Nullable String uiShowHeaters;
+
+    @XStreamAlias("UI-Show-Lights")
+    private @Nullable String uiShowLights;
+
+    @XStreamAlias("UI-Show-Spillover")
+    private @Nullable String uiShowSpillover;
+
+    @XStreamAlias("UI-Show-SuperChlor")
+    private @Nullable String uiShowSuperChlor;
+
+    @XStreamAlias("UI-Show-SuperChlorTimeout")
+    private @Nullable String uiShowSuperChlorTimeout;
+
     public @Nullable String getSystemId() {
         return systemId;
+    }
+
+    public @Nullable String getMspVspSpeedFormat() {
+        return mspVspSpeedFormat;
+    }
+
+    public @Nullable String getMspTimeFormat() {
+        return mspTimeFormat;
+    }
+
+    public @Nullable String getTimeZone() {
+        return timeZone;
+    }
+
+    public @Nullable String getDst() {
+        return dst;
+    }
+
+    public @Nullable String getInternetTime() {
+        return internetTime;
+    }
+
+    public @Nullable String getUnits() {
+        return units;
+    }
+
+    public @Nullable String getMspChlorDisplay() {
+        return mspChlorDisplay;
+    }
+
+    public @Nullable String getMspLanguage() {
+        return mspLanguage;
+    }
+
+    public @Nullable String getUiShowBackyard() {
+        return uiShowBackyard;
+    }
+
+    public @Nullable String getUiShowEquipment() {
+        return uiShowEquipment;
+    }
+
+    public @Nullable String getUiShowHeaters() {
+        return uiShowHeaters;
+    }
+
+    public @Nullable String getUiShowLights() {
+        return uiShowLights;
+    }
+
+    public @Nullable String getUiShowSpillover() {
+        return uiShowSpillover;
+    }
+
+    public @Nullable String getUiShowSuperChlor() {
+        return uiShowSuperChlor;
+    }
+
+    public @Nullable String getUiShowSuperChlorTimeout() {
+        return uiShowSuperChlorTimeout;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -12,7 +12,23 @@ public class ConfigParserTest {
     public void testParsePopulatesAllListsAndAttributes() {
         String xml = "" +
                 "<MSPConfig>" +
-                "  <System systemId='SYS'/>" +
+                "  <System systemId='SYS'>" +
+                "    <Msp-Vsp-Speed-Format>Percent</Msp-Vsp-Speed-Format>" +
+                "    <Msp-Time-Format>12 Hour Format</Msp-Time-Format>" +
+                "    <Time-Zone>America/New_York</Time-Zone>" +
+                "    <DST>Enabled</DST>" +
+                "    <Internet-Time>Disabled</Internet-Time>" +
+                "    <Units>Metric</Units>" +
+                "    <Msp-Chlor-Display>Salt</Msp-Chlor-Display>" +
+                "    <Msp-Language>French</Msp-Language>" +
+                "    <UI-Show-Backyard>true</UI-Show-Backyard>" +
+                "    <UI-Show-Equipment>false</UI-Show-Equipment>" +
+                "    <UI-Show-Heaters>true</UI-Show-Heaters>" +
+                "    <UI-Show-Lights>true</UI-Show-Lights>" +
+                "    <UI-Show-Spillover>false</UI-Show-Spillover>" +
+                "    <UI-Show-SuperChlor>true</UI-Show-SuperChlor>" +
+                "    <UI-Show-SuperChlorTimeout>false</UI-Show-SuperChlorTimeout>" +
+                "  </System>" +
                 "  <Backyard systemId='BY'>" +
                 "    <BodyOfWater systemId='BOW'/>" +
                 "    <Pump systemId='P1' name='Main'/>" +
@@ -45,6 +61,21 @@ public class ConfigParserTest {
 
         SystemConfig system = config.getSystems().get(0);
         assertEquals("SYS", system.getSystemId());
+        assertEquals("Percent", system.getMspVspSpeedFormat());
+        assertEquals("12 Hour Format", system.getMspTimeFormat());
+        assertEquals("America/New_York", system.getTimeZone());
+        assertEquals("Enabled", system.getDst());
+        assertEquals("Disabled", system.getInternetTime());
+        assertEquals("Metric", system.getUnits());
+        assertEquals("Salt", system.getMspChlorDisplay());
+        assertEquals("French", system.getMspLanguage());
+        assertEquals("true", system.getUiShowBackyard());
+        assertEquals("false", system.getUiShowEquipment());
+        assertEquals("true", system.getUiShowHeaters());
+        assertEquals("true", system.getUiShowLights());
+        assertEquals("false", system.getUiShowSpillover());
+        assertEquals("true", system.getUiShowSuperChlor());
+        assertEquals("false", system.getUiShowSuperChlorTimeout());
 
         assertEquals(1, config.getBackyards().size());
 


### PR DESCRIPTION
## Summary
- map MSP System settings such as speed format, time preferences, units, chlorinator display and language
- expose UI toggle values from the System section of the MSP configuration
- extend configuration parsing test coverage for the new System fields

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test *(fails: network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a9586af08323b60baad2d1af6f57