### PR TITLE
Add backyard sensor configuration support

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BackyardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BackyardConfig.java
@@ -20,6 +20,22 @@ public class BackyardConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("serviceModeTimeout")
+    private @Nullable String serviceModeTimeout;
+
+    @XStreamAlias("Service-Mode-Timeout")
+    private @Nullable String serviceModeTimeoutElement;
+
     @XStreamImplicit(itemFieldName = "BodyOfWater")
     private final List<BodyOfWaterConfig> bodiesOfWater = new ArrayList<>();
 
@@ -44,8 +60,19 @@ public class BackyardConfig {
     @XStreamImplicit(itemFieldName = "Relay")
     private final List<RelayConfig> relays = new ArrayList<>();
 
+    @XStreamImplicit(itemFieldName = "Sensor")
+    private final List<SensorConfig> sensors = new ArrayList<>();
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getServiceModeTimeout() {
+        return serviceModeTimeout != null ? serviceModeTimeout : serviceModeTimeoutElement;
     }
 
     public List<BodyOfWaterConfig> getBodiesOfWater() {
@@ -78,6 +105,10 @@ public class BackyardConfig {
 
     public List<RelayConfig> getRelays() {
         return relays;
+    }
+
+    public List<SensorConfig> getSensors() {
+        return sensors;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
@@ -18,7 +18,7 @@ public final class ConfigParser {
         XSTREAM.ignoreUnknownElements();
         XSTREAM.addPermission(AnyTypePermission.ANY);
         XSTREAM.processAnnotations(new Class<?>[] { MspConfig.class, SystemConfig.class, BackyardConfig.class,
-                BodyOfWaterConfig.class, PumpConfig.class, FilterConfig.class, HeaterConfig.class,
+                BodyOfWaterConfig.class, PumpConfig.class, FilterConfig.class, HeaterConfig.class, SensorConfig.class,
                 VirtualHeaterConfig.class, ChlorinatorConfig.class, ColorLogicLightConfig.class, RelayConfig.class,
                 SchedulesConfig.class, ScheduleConfig.class, ScheduleActionConfig.class, DeviceConfig.class,
                 ParameterConfig.class, DmtConfig.class });

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SensorConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SensorConfig.java
@@ -1,0 +1,56 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+
+/**
+ * Representation of a Sensor element.
+ */
+@NonNullByDefault
+@XStreamAlias("Sensor")
+public class SensorConfig {
+    @XStreamAsAttribute
+    @XStreamAlias("systemId")
+    private @Nullable String systemId;
+
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String type;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String units;
+
+    @XStreamAlias("Units")
+    private @Nullable String unitsElement;
+
+    public @Nullable String getSystemId() {
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getType() {
+        return type != null ? type : typeElement;
+    }
+
+    public @Nullable String getUnits() {
+        return units != null ? units : unitsElement;
+    }
+}
+

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -29,7 +29,16 @@ public class ConfigParserTest {
                 "    <UI-Show-SuperChlor>true</UI-Show-SuperChlor>" +
                 "    <UI-Show-SuperChlorTimeout>false</UI-Show-SuperChlorTimeout>" +
                 "  </System>" +
-                "  <Backyard systemId='BY'>" +
+                "  <Backyard>" +
+                "    <System-Id>BY</System-Id>" +
+                "    <Name>Main Backyard</Name>" +
+                "    <Service-Mode-Timeout>15</Service-Mode-Timeout>" +
+                "    <Sensor>" +
+                "      <System-Id>SEN1</System-Id>" +
+                "      <Name>Water Sensor</Name>" +
+                "      <Type>SENSOR_WATER_TEMP</Type>" +
+                "      <Units>UNITS_FAHRENHEIT</Units>" +
+                "    </Sensor>" +
                 "    <BodyOfWater systemId='BOW'/>" +
                 "    <Pump systemId='P1' name='Main'/>" +
                 "    <Filter systemId='F1' pumpId='P1'/>" +
@@ -81,6 +90,8 @@ public class ConfigParserTest {
 
         BackyardConfig backyard = config.getBackyards().get(0);
         assertEquals("BY", backyard.getSystemId());
+        assertEquals("Main Backyard", backyard.getName());
+        assertEquals("15", backyard.getServiceModeTimeout());
         assertEquals(1, backyard.getBodiesOfWater().size());
         assertEquals("BOW", backyard.getBodiesOfWater().get(0).getSystemId());
 
@@ -104,6 +115,13 @@ public class ConfigParserTest {
 
         assertEquals(1, backyard.getChlorinators().size());
         assertEquals("C1", backyard.getChlorinators().get(0).getSystemId());
+
+        assertEquals(1, backyard.getSensors().size());
+        SensorConfig sensor = backyard.getSensors().get(0);
+        assertEquals("SEN1", sensor.getSystemId());
+        assertEquals("Water Sensor", sensor.getName());
+        assertEquals("SENSOR_WATER_TEMP", sensor.getType());
+        assertEquals("UNITS_FAHRENHEIT", sensor.getUnits());
 
         assertEquals(1, backyard.getColorLogicLights().size());
         assertEquals("L1", backyard.getColorLogicLights().get(0).getSystemId());


### PR DESCRIPTION
## Summary
- expose Backyard metadata fields for System-Id, Name and Service-Mode-Timeout with element fallbacks
- add a SensorConfig DTO and map Backyard Sensor collections implicitly
- cover the new configuration structures in ConfigParser unit tests

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: unable to resolve parent POM because repo.maven.apache.org is unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ad3156d083238b5f5177ceb37a66