### PR TITLE
Refine body of water parsing and discovery

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BackyardConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BackyardConfig.java
@@ -42,26 +42,8 @@ public class BackyardConfig {
     @XStreamImplicit(itemFieldName = "Pump")
     private final List<PumpConfig> pumps = new ArrayList<>();
 
-    @XStreamImplicit(itemFieldName = "Filter")
-    private final List<FilterConfig> filters = new ArrayList<>();
-
-    @XStreamImplicit(itemFieldName = "Heater")
-    private final List<HeaterConfig> heaters = new ArrayList<>();
-
     @XStreamImplicit(itemFieldName = "VirtualHeater")
     private final List<VirtualHeaterConfig> virtualHeaters = new ArrayList<>();
-
-    @XStreamImplicit(itemFieldName = "Chlorinator")
-    private final List<ChlorinatorConfig> chlorinators = new ArrayList<>();
-
-    @XStreamImplicit(itemFieldName = "ColorLogic-Light")
-    private final List<ColorLogicLightConfig> colorLogicLights = new ArrayList<>();
-
-    @XStreamImplicit(itemFieldName = "Relay")
-    private final List<RelayConfig> relays = new ArrayList<>();
-
-    @XStreamImplicit(itemFieldName = "Sensor")
-    private final List<SensorConfig> sensors = new ArrayList<>();
 
     public @Nullable String getSystemId() {
         return systemId != null ? systemId : systemIdElement;
@@ -83,32 +65,8 @@ public class BackyardConfig {
         return pumps;
     }
 
-    public List<FilterConfig> getFilters() {
-        return filters;
-    }
-
-    public List<HeaterConfig> getHeaters() {
-        return heaters;
-    }
-
     public List<VirtualHeaterConfig> getVirtualHeaters() {
         return virtualHeaters;
-    }
-
-    public List<ChlorinatorConfig> getChlorinators() {
-        return chlorinators;
-    }
-
-    public List<ColorLogicLightConfig> getColorLogicLights() {
-        return colorLogicLights;
-    }
-
-    public List<RelayConfig> getRelays() {
-        return relays;
-    }
-
-    public List<SensorConfig> getSensors() {
-        return sensors;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BodyOfWaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/BodyOfWaterConfig.java
@@ -1,10 +1,14 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Representation of a BodyOfWater element.
@@ -16,8 +20,232 @@ public class BodyOfWaterConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String type;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sharedType")
+    private @Nullable String sharedTypeAttribute;
+
+    @XStreamAlias("Shared-Type")
+    private @Nullable String sharedTypeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sharedPriority")
+    private @Nullable String sharedPriorityAttribute;
+
+    @XStreamAlias("Shared-Priority")
+    private @Nullable String sharedPriorityElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sharedEquipmentSystemId")
+    private @Nullable String sharedEquipmentSystemIdAttribute;
+
+    @XStreamAlias("Shared-Equipment-System-ID")
+    private @Nullable String sharedEquipmentSystemIdElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("supportsSpillover")
+    private @Nullable String supportsSpilloverAttribute;
+
+    @XStreamAlias("Supports-Spillover")
+    private @Nullable String supportsSpilloverElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("useSpilloverForFilterOperations")
+    private @Nullable String useSpilloverForFilterOperationsAttribute;
+
+    @XStreamAlias("Use-Spillover-For-Filter-Operations")
+    private @Nullable String useSpilloverForFilterOperationsElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("spilloverMode")
+    private @Nullable String spilloverModeAttribute;
+
+    @XStreamAlias("Spillover-Mode")
+    private @Nullable String spilloverModeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("spilloverManualTimeout")
+    private @Nullable String spilloverManualTimeoutAttribute;
+
+    @XStreamAlias("Spillover-Manual-Timeout")
+    private @Nullable String spilloverManualTimeoutElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("spilloverTimedPercent")
+    private @Nullable String spilloverTimedPercentAttribute;
+
+    @XStreamAlias("Spillover-Timed-Percent")
+    private @Nullable String spilloverTimedPercentElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("spilloverTimedTimeout")
+    private @Nullable String spilloverTimedTimeoutAttribute;
+
+    @XStreamAlias("Spillover-Timed-Timeout")
+    private @Nullable String spilloverTimedTimeoutElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("freezeProtectEnabled")
+    private @Nullable String freezeProtectEnabledAttribute;
+
+    @XStreamAlias("Freeze-Protect-Enabled")
+    private @Nullable String freezeProtectEnabledElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("freezeProtectOverride")
+    private @Nullable String freezeProtectOverrideAttribute;
+
+    @XStreamAlias("Freeze-Protect-Override")
+    private @Nullable String freezeProtectOverrideElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("freezeProtectSetPoint")
+    private @Nullable String freezeProtectSetPointAttribute;
+
+    @XStreamAlias("Freeze-Protect-Set-Point")
+    private @Nullable String freezeProtectSetPointElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sizeInGallons")
+    private @Nullable String sizeInGallonsAttribute;
+
+    @XStreamAlias("Size-In-Gallons")
+    private @Nullable String sizeInGallonsElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sizeInLiters")
+    private @Nullable String sizeInLitersAttribute;
+
+    @XStreamAlias("Size-In-Liters")
+    private @Nullable String sizeInLitersElement;
+
+    @XStreamImplicit(itemFieldName = "Filter")
+    private final List<FilterConfig> filters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Heater")
+    private final List<HeaterConfig> heaters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Relay")
+    private final List<RelayConfig> relays = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "ColorLogic-Light")
+    private final List<ColorLogicLightConfig> colorLogicLights = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Sensor")
+    private final List<SensorConfig> sensors = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Chlorinator")
+    private final List<ChlorinatorConfig> chlorinators = new ArrayList<>();
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getType() {
+        return type != null ? type : typeElement;
+    }
+
+    public @Nullable String getSharedType() {
+        return sharedTypeAttribute != null ? sharedTypeAttribute : sharedTypeElement;
+    }
+
+    public @Nullable String getSharedPriority() {
+        return sharedPriorityAttribute != null ? sharedPriorityAttribute : sharedPriorityElement;
+    }
+
+    public @Nullable String getSharedEquipmentSystemId() {
+        return sharedEquipmentSystemIdAttribute != null ? sharedEquipmentSystemIdAttribute
+                : sharedEquipmentSystemIdElement;
+    }
+
+    public @Nullable String getSupportsSpillover() {
+        return supportsSpilloverAttribute != null ? supportsSpilloverAttribute : supportsSpilloverElement;
+    }
+
+    public @Nullable String getUseSpilloverForFilterOperations() {
+        return useSpilloverForFilterOperationsAttribute != null ? useSpilloverForFilterOperationsAttribute
+                : useSpilloverForFilterOperationsElement;
+    }
+
+    public @Nullable String getSpilloverMode() {
+        return spilloverModeAttribute != null ? spilloverModeAttribute : spilloverModeElement;
+    }
+
+    public @Nullable String getSpilloverManualTimeout() {
+        return spilloverManualTimeoutAttribute != null ? spilloverManualTimeoutAttribute
+                : spilloverManualTimeoutElement;
+    }
+
+    public @Nullable String getSpilloverTimedPercent() {
+        return spilloverTimedPercentAttribute != null ? spilloverTimedPercentAttribute
+                : spilloverTimedPercentElement;
+    }
+
+    public @Nullable String getSpilloverTimedTimeout() {
+        return spilloverTimedTimeoutAttribute != null ? spilloverTimedTimeoutAttribute
+                : spilloverTimedTimeoutElement;
+    }
+
+    public @Nullable String getFreezeProtectEnabled() {
+        return freezeProtectEnabledAttribute != null ? freezeProtectEnabledAttribute : freezeProtectEnabledElement;
+    }
+
+    public @Nullable String getFreezeProtectOverride() {
+        return freezeProtectOverrideAttribute != null ? freezeProtectOverrideAttribute : freezeProtectOverrideElement;
+    }
+
+    public @Nullable String getFreezeProtectSetPoint() {
+        return freezeProtectSetPointAttribute != null ? freezeProtectSetPointAttribute : freezeProtectSetPointElement;
+    }
+
+    public @Nullable String getSizeInGallons() {
+        return sizeInGallonsAttribute != null ? sizeInGallonsAttribute : sizeInGallonsElement;
+    }
+
+    public @Nullable String getSizeInLiters() {
+        return sizeInLitersAttribute != null ? sizeInLitersAttribute : sizeInLitersElement;
+    }
+
+    public List<FilterConfig> getFilters() {
+        return filters;
+    }
+
+    public List<HeaterConfig> getHeaters() {
+        return heaters;
+    }
+
+    public List<RelayConfig> getRelays() {
+        return relays;
+    }
+
+    public List<ColorLogicLightConfig> getColorLogicLights() {
+        return colorLogicLights;
+    }
+
+    public List<SensorConfig> getSensors() {
+        return sensors;
+    }
+
+    public List<ChlorinatorConfig> getChlorinators() {
+        return chlorinators;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardException;
 import org.openhab.binding.haywardomnilogiclocal.internal.HaywardTypeToRequest;
@@ -31,6 +32,7 @@ import org.openhab.binding.haywardomnilogiclocal.internal.config.HeaterConfig;
 import org.openhab.binding.haywardomnilogiclocal.internal.config.MspConfig;
 import org.openhab.binding.haywardomnilogiclocal.internal.config.PumpConfig;
 import org.openhab.binding.haywardomnilogiclocal.internal.config.RelayConfig;
+import org.openhab.binding.haywardomnilogiclocal.internal.config.SensorConfig;
 import org.openhab.binding.haywardomnilogiclocal.internal.config.VirtualHeaterConfig;
 import org.openhab.binding.haywardomnilogiclocal.internal.handler.HaywardBridgeHandler;
 import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
@@ -76,131 +78,149 @@ public class HaywardDiscoveryService extends AbstractThingHandlerDiscoveryServic
             Map<String, Object> backyardProps = new HashMap<>();
             backyardProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BACKYARD);
             String systemId = backyard.getSystemId();
-            if (systemId != null) {
-                backyardProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemId);
-            }
+            putIfNotNull(backyardProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, systemId);
             onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_BACKYARD, "Backyard", backyardProps);
 
             for (BodyOfWaterConfig bow : backyard.getBodiesOfWater()) {
                 Map<String, Object> bowProps = new HashMap<>();
                 bowProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.BOW);
                 String bowId = bow.getSystemId();
-                if (bowId != null) {
-                    bowProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, bowId);
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, bowId);
+                addBowContext(bowProps, bow);
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_BOW_TYPE, bow.getType());
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_BOW_SHAREDTYPE, bow.getSharedType());
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_BOW_SHAREDPRIORITY, bow.getSharedPriority());
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_BOW_SHAREDEQUIPID,
+                        bow.getSharedEquipmentSystemId());
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_BOW_SUPPORTSSPILLOVER,
+                        bow.getSupportsSpillover());
+                putIfNotNull(bowProps, HaywardBindingConstants.PROPERTY_BOW_SIZEINGALLONS, bow.getSizeInGallons());
+
+                String bowLabel = bow.getName();
+                if (bowLabel == null) {
+                    bowLabel = bowId != null ? bowId : "BodyOfWater";
                 }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_BOW, bowId != null ? bowId : "BodyOfWater",
-                        bowProps);
+                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_BOW, bowLabel, bowProps);
+
+                for (FilterConfig filter : bow.getFilters()) {
+                    Map<String, Object> filterProps = new HashMap<>();
+                    filterProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
+                    String filterId = filter.getSystemId();
+                    putIfNotNull(filterProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, filterId);
+                    addBowContext(filterProps, bow);
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_FILTER,
+                            filterId != null ? filterId : "Filter", filterProps);
+                }
+
+                for (HeaterConfig heater : bow.getHeaters()) {
+                    Map<String, Object> heaterProps = new HashMap<>();
+                    heaterProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
+                    String heaterId = heater.getSystemId();
+                    putIfNotNull(heaterProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, heaterId);
+                    addBowContext(heaterProps, bow);
+                    putIfNotNull(heaterProps, HaywardBindingConstants.PROPERTY_HEATER_TYPE, heater.getType());
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_HEATER,
+                            heaterId != null ? heaterId : "Heater", heaterProps);
+                }
+
+                for (ChlorinatorConfig chlorinator : bow.getChlorinators()) {
+                    Map<String, Object> chlorProps = new HashMap<>();
+                    chlorProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
+                    String id = chlorinator.getSystemId();
+                    putIfNotNull(chlorProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
+                    addBowContext(chlorProps, bow);
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_CHLORINATOR,
+                            id != null ? id : "Chlorinator", chlorProps);
+                }
+
+                for (ColorLogicLightConfig light : bow.getColorLogicLights()) {
+                    Map<String, Object> lightProps = new HashMap<>();
+                    lightProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
+                    String id = light.getSystemId();
+                    putIfNotNull(lightProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
+                    addBowContext(lightProps, bow);
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_COLORLOGIC,
+                            id != null ? id : "ColorLogic", lightProps);
+                }
+
+                for (RelayConfig relay : bow.getRelays()) {
+                    String id = relay.getSystemId();
+                    String relayType = relay.getType();
+                    if ("RLY_VALVE_ACTUATOR".equals(relayType)) {
+                        Map<String, Object> valveProps = new HashMap<>();
+                        valveProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VALVEACTUATOR);
+                        putIfNotNull(valveProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
+                        putIfNotNull(valveProps, HaywardBindingConstants.PROPERTY_RELAY_TYPE, relayType);
+                        putIfNotNull(valveProps, HaywardBindingConstants.PROPERTY_RELAY_FUNCTION, relay.getFunction());
+                        addBowContext(valveProps, bow);
+                        String name = relay.getName();
+                        if (name == null) {
+                            name = id != null ? id : "ValveActuator";
+                        }
+                        onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_VALVEACTUATOR, name, valveProps);
+                        continue;
+                    }
+
+                    Map<String, Object> relayProps = new HashMap<>();
+                    relayProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
+                    putIfNotNull(relayProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
+                    addBowContext(relayProps, bow);
+                    String name = relay.getName();
+                    if (name == null) {
+                        name = id != null ? id : "Relay";
+                    }
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_RELAY, name, relayProps);
+                }
+
+                for (SensorConfig sensor : bow.getSensors()) {
+                    Map<String, Object> sensorProps = new HashMap<>();
+                    sensorProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.SENSOR);
+                    String sensorId = sensor.getSystemId();
+                    putIfNotNull(sensorProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, sensorId);
+                    addBowContext(sensorProps, bow);
+                    putIfNotNull(sensorProps, HaywardBindingConstants.PROPERTY_SENSOR_TYPE, sensor.getType());
+                    putIfNotNull(sensorProps, HaywardBindingConstants.PROPERTY_SENSOR_UNITS, sensor.getUnits());
+                    String name = sensor.getName();
+                    if (name == null) {
+                        name = sensorId != null ? sensorId : "Sensor";
+                    }
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_SENSOR, name, sensorProps);
+                }
             }
 
             for (PumpConfig pump : backyard.getPumps()) {
                 Map<String, Object> pumpProps = new HashMap<>();
                 pumpProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
                 String pumpId = pump.getSystemId();
-                if (pumpId != null) {
-                    pumpProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, pumpId);
-                }
+                putIfNotNull(pumpProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, pumpId);
                 String name = pump.getName() != null ? pump.getName() : pumpId;
                 if (name == null) {
                     name = "Pump";
                 }
                 onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_PUMP, name, pumpProps);
             }
-
-            for (FilterConfig filter : backyard.getFilters()) {
-                Map<String, Object> filterProps = new HashMap<>();
-                filterProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.FILTER);
-                String filterId = filter.getSystemId();
-                if (filterId != null) {
-                    filterProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, filterId);
-                }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_FILTER,
-                        filterId != null ? filterId : "Filter", filterProps);
-            }
-
-            for (HeaterConfig heater : backyard.getHeaters()) {
-                Map<String, Object> heaterProps = new HashMap<>();
-                heaterProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.HEATER);
-                String heaterId = heater.getSystemId();
-                if (heaterId != null) {
-                    heaterProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, heaterId);
-                }
-                String type = heater.getType();
-                if (type != null) {
-                    heaterProps.put(HaywardBindingConstants.PROPERTY_HEATER_TYPE, type);
-                }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_HEATER,
-                        heaterId != null ? heaterId : "Heater", heaterProps);
-            }
-
-            for (ChlorinatorConfig chlorinator : backyard.getChlorinators()) {
-                Map<String, Object> chlorProps = new HashMap<>();
-                chlorProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.CHLORINATOR);
-                String id = chlorinator.getSystemId();
-                if (id != null) {
-                    chlorProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
-                }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_CHLORINATOR, id != null ? id : "Chlorinator",
-                        chlorProps);
-            }
-
-            for (ColorLogicLightConfig light : backyard.getColorLogicLights()) {
-                Map<String, Object> lightProps = new HashMap<>();
-                lightProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.COLORLOGIC);
-                String id = light.getSystemId();
-                if (id != null) {
-                    lightProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
-                }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_COLORLOGIC, id != null ? id : "ColorLogic",
-                        lightProps);
-            }
-
-            for (RelayConfig relay : backyard.getRelays()) {
-                String id = relay.getSystemId();
-                String relayType = relay.getType();
-                if ("RLY_VALVE_ACTUATOR".equals(relayType)) {
-                    Map<String, Object> valveProps = new HashMap<>();
-                    valveProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VALVEACTUATOR);
-                    if (id != null) {
-                        valveProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
-                    }
-                    if (relayType != null) {
-                        valveProps.put(HaywardBindingConstants.PROPERTY_RELAY_TYPE, relayType);
-                    }
-                    String function = relay.getFunction();
-                    if (function != null) {
-                        valveProps.put(HaywardBindingConstants.PROPERTY_RELAY_FUNCTION, function);
-                    }
-                    String name = relay.getName();
-                    if (name == null) {
-                        name = id != null ? id : "ValveActuator";
-                    }
-                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_VALVEACTUATOR, name, valveProps);
-                    continue;
-                }
-
-                Map<String, Object> relayProps = new HashMap<>();
-                relayProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.RELAY);
-                if (id != null) {
-                    relayProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
-                }
-                String name = relay.getName();
-                if (name == null) {
-                    name = id != null ? id : "Relay";
-                }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_RELAY, name, relayProps);
-            }
-
             for (VirtualHeaterConfig vh : backyard.getVirtualHeaters()) {
                 Map<String, Object> vhProps = new HashMap<>();
                 vhProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.VIRTUALHEATER);
                 String id = vh.getSystemId();
-                if (id != null) {
-                    vhProps.put(HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
-                }
+                putIfNotNull(vhProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, id);
                 onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_VIRTUALHEATER,
                         id != null ? id : "VirtualHeater", vhProps);
             }
         }
+    }
+
+    private void putIfNotNull(Map<String, Object> properties, String key, @Nullable String value) {
+        if (value != null) {
+            properties.put(key, value);
+        }
+    }
+
+    private void addBowContext(Map<String, Object> properties, BodyOfWaterConfig bow) {
+        String bowId = bow.getSystemId();
+        putIfNotNull(properties, HaywardBindingConstants.PROPERTY_BOWID, bowId);
+        String bowName = bow.getName();
+        putIfNotNull(properties, HaywardBindingConstants.PROPERTY_BOWNAME, bowName);
     }
 
     public void onDeviceDiscovered(ThingTypeUID thingType, String label, Map<String, Object> properties) {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -33,20 +33,36 @@ public class ConfigParserTest {
                 "    <System-Id>BY</System-Id>" +
                 "    <Name>Main Backyard</Name>" +
                 "    <Service-Mode-Timeout>15</Service-Mode-Timeout>" +
-                "    <Sensor>" +
-                "      <System-Id>SEN1</System-Id>" +
-                "      <Name>Water Sensor</Name>" +
-                "      <Type>SENSOR_WATER_TEMP</Type>" +
-                "      <Units>UNITS_FAHRENHEIT</Units>" +
-                "    </Sensor>" +
-                "    <BodyOfWater systemId='BOW'/>" +
+                "    <BodyOfWater systemId='BOW' type='BOW_POOL' sharedType='BOW_SHARED_EQUIPMENT' supportsSpillover='yes'" +
+                "        spilloverMode='manual' spilloverTimedPercent='50' freezeProtectEnabled='yes'" +
+                "        freezeProtectSetPoint='38' sizeInLiters='56781'>" +
+                "      <Name>Main Pool</Name>" +
+                "      <Type>BOW_POOL</Type>" +
+                "      <Shared-Type>BOW_SHARED_EQUIPMENT</Shared-Type>" +
+                "      <Shared-Priority>SHARED_EQUIPMENT_HIGH_PRIORITY</Shared-Priority>" +
+                "      <Shared-Equipment-System-ID>BOW2</Shared-Equipment-System-ID>" +
+                "      <Use-Spillover-For-Filter-Operations>yes</Use-Spillover-For-Filter-Operations>" +
+                "      <Spillover-Manual-Timeout>10</Spillover-Manual-Timeout>" +
+                "      <Spillover-Timed-Timeout>20</Spillover-Timed-Timeout>" +
+                "      <Freeze-Protect-Override>no</Freeze-Protect-Override>" +
+                "      <Size-In-Gallons>15000</Size-In-Gallons>" +
+                "      <Filter systemId='F1' pumpId='P1'/>" +
+                "      <Heater systemId='H1' type='gas'/>" +
+                "      <Chlorinator systemId='C1'/>" +
+                "      <ColorLogic-Light systemId='L1'/>" +
+                "      <Relay systemId='R1' name='Aux1'>" +
+                "        <Type>RLY_HIGH_VOLTAGE_RELAY</Type>" +
+                "        <Function>GENERIC</Function>" +
+                "      </Relay>" +
+                "      <Sensor>" +
+                "        <System-Id>SEN1</System-Id>" +
+                "        <Name>Water Sensor</Name>" +
+                "        <Type>SENSOR_WATER_TEMP</Type>" +
+                "        <Units>UNITS_FAHRENHEIT</Units>" +
+                "      </Sensor>" +
+                "    </BodyOfWater>" +
                 "    <Pump systemId='P1' name='Main'/>" +
-                "    <Filter systemId='F1' pumpId='P1'/>" +
-                "    <Heater systemId='H1' type='gas'/>" +
                 "    <VirtualHeater systemId='VH1'/>" +
-                "    <Chlorinator systemId='C1'/>" +
-                "    <ColorLogic-Light systemId='L1'/>" +
-                "    <Relay systemId='R1' name='Aux1'/>" +
                 "  </Backyard>" +
                 "  <Schedules>" +
                 "    <Schedule systemId='SCH1' name='Filter' type='equipment'>" +
@@ -93,43 +109,60 @@ public class ConfigParserTest {
         assertEquals("Main Backyard", backyard.getName());
         assertEquals("15", backyard.getServiceModeTimeout());
         assertEquals(1, backyard.getBodiesOfWater().size());
-        assertEquals("BOW", backyard.getBodiesOfWater().get(0).getSystemId());
+        BodyOfWaterConfig bow = backyard.getBodiesOfWater().get(0);
+        assertEquals("BOW", bow.getSystemId());
+        assertEquals("Main Pool", bow.getName());
+        assertEquals("BOW_POOL", bow.getType());
+        assertEquals("BOW_SHARED_EQUIPMENT", bow.getSharedType());
+        assertEquals("SHARED_EQUIPMENT_HIGH_PRIORITY", bow.getSharedPriority());
+        assertEquals("BOW2", bow.getSharedEquipmentSystemId());
+        assertEquals("yes", bow.getSupportsSpillover());
+        assertEquals("yes", bow.getUseSpilloverForFilterOperations());
+        assertEquals("manual", bow.getSpilloverMode());
+        assertEquals("10", bow.getSpilloverManualTimeout());
+        assertEquals("50", bow.getSpilloverTimedPercent());
+        assertEquals("20", bow.getSpilloverTimedTimeout());
+        assertEquals("yes", bow.getFreezeProtectEnabled());
+        assertEquals("no", bow.getFreezeProtectOverride());
+        assertEquals("38", bow.getFreezeProtectSetPoint());
+        assertEquals("15000", bow.getSizeInGallons());
+        assertEquals("56781", bow.getSizeInLiters());
+
+        assertEquals(1, bow.getFilters().size());
+        FilterConfig filter = bow.getFilters().get(0);
+        assertEquals("F1", filter.getSystemId());
+        assertEquals("P1", filter.getPumpId());
+
+        assertEquals(1, bow.getHeaters().size());
+        HeaterConfig heater = bow.getHeaters().get(0);
+        assertEquals("H1", heater.getSystemId());
+        assertEquals("gas", heater.getType());
+
+        assertEquals(1, bow.getChlorinators().size());
+        assertEquals("C1", bow.getChlorinators().get(0).getSystemId());
+
+        assertEquals(1, bow.getColorLogicLights().size());
+        assertEquals("L1", bow.getColorLogicLights().get(0).getSystemId());
+
+        assertEquals(1, bow.getRelays().size());
+        RelayConfig relay = bow.getRelays().get(0);
+        assertEquals("R1", relay.getSystemId());
+        assertEquals("Aux1", relay.getName());
+
+        assertEquals(1, bow.getSensors().size());
+        SensorConfig sensor = bow.getSensors().get(0);
+        assertEquals("SEN1", sensor.getSystemId());
+        assertEquals("Water Sensor", sensor.getName());
+        assertEquals("SENSOR_WATER_TEMP", sensor.getType());
+        assertEquals("UNITS_FAHRENHEIT", sensor.getUnits());
 
         assertEquals(1, backyard.getPumps().size());
         PumpConfig pump = backyard.getPumps().get(0);
         assertEquals("P1", pump.getSystemId());
         assertEquals("Main", pump.getName());
 
-        assertEquals(1, backyard.getFilters().size());
-        FilterConfig filter = backyard.getFilters().get(0);
-        assertEquals("F1", filter.getSystemId());
-        assertEquals("P1", filter.getPumpId());
-
-        assertEquals(1, backyard.getHeaters().size());
-        HeaterConfig heater = backyard.getHeaters().get(0);
-        assertEquals("H1", heater.getSystemId());
-        assertEquals("gas", heater.getType());
-
         assertEquals(1, backyard.getVirtualHeaters().size());
         assertEquals("VH1", backyard.getVirtualHeaters().get(0).getSystemId());
-
-        assertEquals(1, backyard.getChlorinators().size());
-        assertEquals("C1", backyard.getChlorinators().get(0).getSystemId());
-
-        assertEquals(1, backyard.getSensors().size());
-        SensorConfig sensor = backyard.getSensors().get(0);
-        assertEquals("SEN1", sensor.getSystemId());
-        assertEquals("Water Sensor", sensor.getName());
-        assertEquals("SENSOR_WATER_TEMP", sensor.getType());
-        assertEquals("UNITS_FAHRENHEIT", sensor.getUnits());
-
-        assertEquals(1, backyard.getColorLogicLights().size());
-        assertEquals("L1", backyard.getColorLogicLights().get(0).getSystemId());
-
-        assertEquals(1, backyard.getRelays().size());
-        RelayConfig relay = backyard.getRelays().get(0);
-        assertEquals("R1", relay.getSystemId());
-        assertEquals("Aux1", relay.getName());
 
         assertEquals(1, config.getSchedules().size());
         ScheduleConfig schedule = config.getSchedules().get(0);

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryServiceTest.java
@@ -37,16 +37,23 @@ public class HaywardDiscoveryServiceTest {
                 "<MSPConfig>" +
                 "  <System systemId='SYS'/>" +
                 "  <Backyard systemId='BY'>" +
-                "    <BodyOfWater systemId='BOW1'/>" +
-                "    <BodyOfWater systemId='BOW2'/>" +
+                "    <BodyOfWater systemId='BOW1' name='Pool' type='BOW_POOL' sharedType='BOW_SHARED_EQUIPMENT'" +
+                "        sharedPriority='SHARED_EQUIPMENT_HIGH_PRIORITY' sharedEquipmentSystemId='BOW2'" +
+                "        supportsSpillover='yes' sizeInGallons='15000'>" +
+                "      <Filter systemId='F1' pumpId='P1'/>" +
+                "      <Heater systemId='H1' type='gas'/>" +
+                "      <Chlorinator systemId='C1'/>" +
+                "      <ColorLogic-Light systemId='L1'/>" +
+                "      <Relay systemId='R1' name='Relay1'>" +
+                "        <Type>RLY_HIGH_VOLTAGE_RELAY</Type>" +
+                "      </Relay>" +
+                "      <Sensor systemId='S1' name='Water' type='SENSOR_WATER_TEMP' units='UNITS_FAHRENHEIT'/>" +
+                "    </BodyOfWater>" +
+                "    <BodyOfWater systemId='BOW2'>" +
+                "      <Filter systemId='F2' pumpId='P2'/>" +
+                "    </BodyOfWater>" +
                 "    <Pump systemId='P1' name='Pump1'/>" +
                 "    <Pump systemId='P2' name='Pump2'/>" +
-                "    <Filter systemId='F1' pumpId='P1'/>" +
-                "    <Filter systemId='F2' pumpId='P2'/>" +
-                "    <Heater systemId='H1' type='gas'/>" +
-                "    <Chlorinator systemId='C1'/>" +
-                "    <ColorLogic-Light systemId='L1'/>" +
-                "    <Relay systemId='R1' name='Relay1'/>" +
                 "    <VirtualHeater systemId='VH1'/>" +
                 "  </Backyard>" +
                 "</MSPConfig>";
@@ -54,10 +61,32 @@ public class HaywardDiscoveryServiceTest {
         TestDiscoveryService service = new TestDiscoveryService();
         service.mspConfigDiscovery(xml);
 
-        assertEquals(12, service.types.size());
+        assertEquals(13, service.types.size());
         assertEquals(2, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_PUMP)).count());
         assertEquals(2, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_FILTER)).count());
         assertEquals(2, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_BOW)).count());
+        assertEquals(1, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_SENSOR)).count());
+
+        Map<String, Object> bowProps = null;
+        for (int i = 0; i < service.types.size(); i++) {
+            if (service.types.get(i).equals(HaywardBindingConstants.THING_TYPE_BOW)) {
+                Map<String, Object> properties = service.propertyMaps.get(i);
+                if ("BOW1".equals(properties.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID))) {
+                    bowProps = properties;
+                    break;
+                }
+            }
+        }
+
+        assertNotNull(bowProps);
+        assertEquals("Pool", bowProps.get(HaywardBindingConstants.PROPERTY_BOWNAME));
+        assertEquals("BOW1", bowProps.get(HaywardBindingConstants.PROPERTY_BOWID));
+        assertEquals("BOW_POOL", bowProps.get(HaywardBindingConstants.PROPERTY_BOW_TYPE));
+        assertEquals("BOW_SHARED_EQUIPMENT", bowProps.get(HaywardBindingConstants.PROPERTY_BOW_SHAREDTYPE));
+        assertEquals("SHARED_EQUIPMENT_HIGH_PRIORITY", bowProps.get(HaywardBindingConstants.PROPERTY_BOW_SHAREDPRIORITY));
+        assertEquals("BOW2", bowProps.get(HaywardBindingConstants.PROPERTY_BOW_SHAREDEQUIPID));
+        assertEquals("yes", bowProps.get(HaywardBindingConstants.PROPERTY_BOW_SUPPORTSSPILLOVER));
+        assertEquals("15000", bowProps.get(HaywardBindingConstants.PROPERTY_BOW_SIZEINGALLONS));
     }
 
     @Test
@@ -66,10 +95,12 @@ public class HaywardDiscoveryServiceTest {
                 "<MSPConfig>" +
                 "  <System systemId='SYS'/>" +
                 "  <Backyard systemId='BY'>" +
-                "    <Relay systemId='VA1' name='Valve'>" +
-                "      <Type>RLY_VALVE_ACTUATOR</Type>" +
-                "      <Function>POOL_RETURN</Function>" +
-                "    </Relay>" +
+                "    <BodyOfWater systemId='BOW1'>" +
+                "      <Relay systemId='VA1' name='Valve'>" +
+                "        <Type>RLY_VALVE_ACTUATOR</Type>" +
+                "        <Function>POOL_RETURN</Function>" +
+                "      </Relay>" +
+                "    </BodyOfWater>" +
                 "  </Backyard>" +
                 "</MSPConfig>";
 
@@ -92,5 +123,6 @@ public class HaywardDiscoveryServiceTest {
         assertEquals("RLY_VALVE_ACTUATOR", valveProps.get(HaywardBindingConstants.PROPERTY_RELAY_TYPE));
         assertEquals("POOL_RETURN", valveProps.get(HaywardBindingConstants.PROPERTY_RELAY_FUNCTION));
         assertEquals("VA1", valveProps.get(HaywardBindingConstants.PROPERTY_SYSTEM_ID));
+        assertEquals("BOW1", valveProps.get(HaywardBindingConstants.PROPERTY_BOWID));
     }
 }


### PR DESCRIPTION
## Summary
- expand the body-of-water configuration to expose metadata such as name, type, spillover settings, and equipment lists
- remove duplicate equipment lists from the backyard configuration and surface nested devices through the body-of-water entries
- update discovery logic and unit tests to consume the new structure and verify body-of-water properties

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test` *(fails: unable to resolve parent POM while offline)*

------
https://chatgpt.com/codex/tasks/task_e_68c8af24fe408323babb6d4d20d75070