### PR TITLE
Expand OmniLogic config parsing

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ChlorinatorConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ChlorinatorConfig.java
@@ -1,10 +1,16 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Chlorinator element.
@@ -16,8 +22,127 @@ public class ChlorinatorConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String nameAttribute;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sharedType")
+    private @Nullable String sharedTypeAttribute;
+
+    @XStreamAlias("Shared-Type")
+    private @Nullable String sharedTypeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String enabledAttribute;
+
+    @XStreamAlias("Enabled")
+    private @Nullable String enabledElement;
+
+    @XStreamAlias("Mode")
+    private @Nullable String mode;
+
+    @XStreamAlias("Timed-Percent")
+    private @Nullable String timedPercent;
+
+    @XStreamAlias("SuperChlor-Timeout")
+    private @Nullable String superChlorTimeout;
+
+    @XStreamAlias("Cell-Type")
+    private @Nullable String cellType;
+
+    @XStreamAlias("ORP-Timeout")
+    private @Nullable String orpTimeout;
+
+    @XStreamImplicit(itemFieldName = "Operation")
+    private final List<OperationConfig> operations = new ArrayList<>();
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return nameAttribute != null ? nameAttribute : nameElement;
+    }
+
+    public @Nullable String getSharedType() {
+        return sharedTypeAttribute != null ? sharedTypeAttribute : sharedTypeElement;
+    }
+
+    public @Nullable String getEnabled() {
+        return enabledAttribute != null ? enabledAttribute : enabledElement;
+    }
+
+    public @Nullable String getMode() {
+        return mode;
+    }
+
+    public @Nullable String getTimedPercent() {
+        return timedPercent;
+    }
+
+    public @Nullable String getSuperChlorTimeout() {
+        return superChlorTimeout;
+    }
+
+    public @Nullable String getCellType() {
+        return cellType;
+    }
+
+    public @Nullable String getOrpTimeout() {
+        return orpTimeout;
+    }
+
+    public List<OperationConfig> getOperations() {
+        return operations;
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Operation")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class OperationConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Action")
+        private final List<ActionConfig> actions = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<ActionConfig> getActions() {
+            return actions;
+        }
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Action")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class ActionConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Device")
+        private final List<DeviceConfig> devices = new ArrayList<>();
+
+        @XStreamImplicit(itemFieldName = "Parameter")
+        private final List<ParameterConfig> parameters = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<DeviceConfig> getDevices() {
+            return devices;
+        }
+
+        public List<ParameterConfig> getParameters() {
+            return parameters;
+        }
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ColorLogicLightConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ColorLogicLightConfig.java
@@ -16,8 +16,31 @@ public class ColorLogicLightConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String nameAttribute;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String typeAttribute;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return nameAttribute != null ? nameAttribute : nameElement;
+    }
+
+    public @Nullable String getType() {
+        return typeAttribute != null ? typeAttribute : typeElement;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/FilterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/FilterConfig.java
@@ -1,10 +1,16 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Filter element.
@@ -16,16 +22,160 @@ public class FilterConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
     @XStreamAsAttribute
     @XStreamAlias("pumpId")
     private @Nullable String pumpId;
 
+    @XStreamAlias("Pump-Id")
+    private @Nullable String pumpIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String nameAttribute;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sharedType")
+    private @Nullable String sharedTypeAttribute;
+
+    @XStreamAlias("Shared-Type")
+    private @Nullable String sharedTypeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("filterType")
+    private @Nullable String filterTypeAttribute;
+
+    @XStreamAlias("Filter-Type")
+    private @Nullable String filterTypeElement;
+
+    @XStreamAlias("Max-Pump-Speed")
+    private @Nullable String maxPumpSpeed;
+
+    @XStreamAlias("Min-Pump-Speed")
+    private @Nullable String minPumpSpeed;
+
+    @XStreamAlias("Max-Pump-RPM")
+    private @Nullable String maxPumpRpm;
+
+    @XStreamAlias("Min-Pump-RPM")
+    private @Nullable String minPumpRpm;
+
+    @XStreamAlias("Vsp-Low-Pump-Speed")
+    private @Nullable String vspLowPumpSpeed;
+
+    @XStreamAlias("Vsp-Medium-Pump-Speed")
+    private @Nullable String vspMediumPumpSpeed;
+
+    @XStreamAlias("Vsp-High-Pump-Speed")
+    private @Nullable String vspHighPumpSpeed;
+
+    @XStreamAlias("Vsp-Custom-Pump-Speed")
+    private @Nullable String vspCustomPumpSpeed;
+
+    @XStreamImplicit(itemFieldName = "Operation")
+    private final List<OperationConfig> operations = new ArrayList<>();
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
     }
 
     public @Nullable String getPumpId() {
-        return pumpId;
+        return pumpId != null ? pumpId : pumpIdElement;
+    }
+
+    public @Nullable String getName() {
+        return nameAttribute != null ? nameAttribute : nameElement;
+    }
+
+    public @Nullable String getSharedType() {
+        return sharedTypeAttribute != null ? sharedTypeAttribute : sharedTypeElement;
+    }
+
+    public @Nullable String getFilterType() {
+        return filterTypeAttribute != null ? filterTypeAttribute : filterTypeElement;
+    }
+
+    public @Nullable String getMaxPumpSpeed() {
+        return maxPumpSpeed;
+    }
+
+    public @Nullable String getMinPumpSpeed() {
+        return minPumpSpeed;
+    }
+
+    public @Nullable String getMaxPumpRpm() {
+        return maxPumpRpm;
+    }
+
+    public @Nullable String getMinPumpRpm() {
+        return minPumpRpm;
+    }
+
+    public @Nullable String getVspLowPumpSpeed() {
+        return vspLowPumpSpeed;
+    }
+
+    public @Nullable String getVspMediumPumpSpeed() {
+        return vspMediumPumpSpeed;
+    }
+
+    public @Nullable String getVspHighPumpSpeed() {
+        return vspHighPumpSpeed;
+    }
+
+    public @Nullable String getVspCustomPumpSpeed() {
+        return vspCustomPumpSpeed;
+    }
+
+    public List<OperationConfig> getOperations() {
+        return operations;
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Operation")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class OperationConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Action")
+        private final List<ActionConfig> actions = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<ActionConfig> getActions() {
+            return actions;
+        }
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Action")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class ActionConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Device")
+        private final List<DeviceConfig> devices = new ArrayList<>();
+
+        @XStreamImplicit(itemFieldName = "Parameter")
+        private final List<ParameterConfig> parameters = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<DeviceConfig> getDevices() {
+            return devices;
+        }
+
+        public List<ParameterConfig> getParameters() {
+            return parameters;
+        }
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HeaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HeaterConfig.java
@@ -1,10 +1,16 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Heater element.
@@ -16,15 +22,177 @@ public class HeaterConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
     @XStreamAsAttribute
     private @Nullable String type;
 
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("sharedType")
+    private @Nullable String sharedTypeAttribute;
+
+    @XStreamAlias("Shared-Type")
+    private @Nullable String sharedTypeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String enabledAttribute;
+
+    @XStreamAlias("Enabled")
+    private @Nullable String enabledElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("currentSetPoint")
+    private @Nullable String currentSetPointAttribute;
+
+    @XStreamAlias("Current-Set-Point")
+    private @Nullable String currentSetPointElement;
+
+    @XStreamAlias("Max-Water-Temp")
+    private @Nullable String maxWaterTemp;
+
+    @XStreamAlias("Min-Settable-Water-Temp")
+    private @Nullable String minSettableWaterTemp;
+
+    @XStreamAlias("Max-Settable-Water-Temp")
+    private @Nullable String maxSettableWaterTemp;
+
+    @XStreamAlias("Cooldown-Enabled")
+    private @Nullable String cooldownEnabled;
+
+    @XStreamImplicit(itemFieldName = "Operation")
+    private final List<OperationConfig> operations = new ArrayList<>();
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
     }
 
     public @Nullable String getType() {
-        return type;
+        return type != null ? type : typeElement;
+    }
+
+    public @Nullable String getSharedType() {
+        return sharedTypeAttribute != null ? sharedTypeAttribute : sharedTypeElement;
+    }
+
+    public @Nullable String getEnabled() {
+        return enabledAttribute != null ? enabledAttribute : enabledElement;
+    }
+
+    public @Nullable String getCurrentSetPoint() {
+        return currentSetPointAttribute != null ? currentSetPointAttribute : currentSetPointElement;
+    }
+
+    public @Nullable String getMaxWaterTemp() {
+        return maxWaterTemp;
+    }
+
+    public @Nullable String getMinSettableWaterTemp() {
+        return minSettableWaterTemp;
+    }
+
+    public @Nullable String getMaxSettableWaterTemp() {
+        return maxSettableWaterTemp;
+    }
+
+    public @Nullable String getCooldownEnabled() {
+        return cooldownEnabled;
+    }
+
+    public List<OperationConfig> getOperations() {
+        return operations;
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Operation")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class OperationConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Action")
+        private final List<ActionConfig> actions = new ArrayList<>();
+
+        @XStreamImplicit(itemFieldName = "Heater-Equipment")
+        private final List<HeaterEquipmentConfig> heaterEquipment = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<ActionConfig> getActions() {
+            return actions;
+        }
+
+        public List<HeaterEquipmentConfig> getHeaterEquipment() {
+            return heaterEquipment;
+        }
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Action")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class ActionConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Device")
+        private final List<DeviceConfig> devices = new ArrayList<>();
+
+        @XStreamImplicit(itemFieldName = "Parameter")
+        private final List<ParameterConfig> parameters = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<DeviceConfig> getDevices() {
+            return devices;
+        }
+
+        public List<ParameterConfig> getParameters() {
+            return parameters;
+        }
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Heater-Equipment")
+    public static class HeaterEquipmentConfig {
+        @XStreamAlias("System-Id")
+        private @Nullable String systemId;
+
+        @XStreamAlias("Name")
+        private @Nullable String name;
+
+        @XStreamAlias("Type")
+        private @Nullable String type;
+
+        @XStreamAlias("Heater-Type")
+        private @Nullable String heaterType;
+
+        @XStreamAlias("Enabled")
+        private @Nullable String enabled;
+
+        public @Nullable String getSystemId() {
+            return systemId;
+        }
+
+        public @Nullable String getName() {
+            return name;
+        }
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public @Nullable String getHeaterType() {
+            return heaterType;
+        }
+
+        public @Nullable String getEnabled() {
+            return enabled;
+        }
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/PumpConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/PumpConfig.java
@@ -1,10 +1,16 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Pump element.
@@ -16,15 +22,147 @@ public class PumpConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
     @XStreamAsAttribute
     private @Nullable String name;
 
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String typeAttribute;
+
+    @XStreamAlias("Type")
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String functionAttribute;
+
+    @XStreamAlias("Function")
+    private @Nullable String functionElement;
+
+    @XStreamAlias("Max-Pump-RPM")
+    private @Nullable String maxPumpRpm;
+
+    @XStreamAlias("Min-Pump-RPM")
+    private @Nullable String minPumpRpm;
+
+    @XStreamAlias("Min-Pump-Speed")
+    private @Nullable String minPumpSpeed;
+
+    @XStreamAlias("Max-Pump-Speed")
+    private @Nullable String maxPumpSpeed;
+
+    @XStreamAlias("Vsp-Medium-Pump-Speed")
+    private @Nullable String vspMediumPumpSpeed;
+
+    @XStreamAlias("Vsp-Custom-Pump-Speed")
+    private @Nullable String vspCustomPumpSpeed;
+
+    @XStreamAlias("Vsp-High-Pump-Speed")
+    private @Nullable String vspHighPumpSpeed;
+
+    @XStreamAlias("Vsp-Low-Pump-Speed")
+    private @Nullable String vspLowPumpSpeed;
+
+    @XStreamImplicit(itemFieldName = "Operation")
+    private final List<OperationConfig> operations = new ArrayList<>();
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
     }
 
     public @Nullable String getName() {
-        return name;
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getType() {
+        return typeAttribute != null ? typeAttribute : typeElement;
+    }
+
+    public @Nullable String getFunction() {
+        return functionAttribute != null ? functionAttribute : functionElement;
+    }
+
+    public @Nullable String getMaxPumpRpm() {
+        return maxPumpRpm;
+    }
+
+    public @Nullable String getMinPumpRpm() {
+        return minPumpRpm;
+    }
+
+    public @Nullable String getMinPumpSpeed() {
+        return minPumpSpeed;
+    }
+
+    public @Nullable String getMaxPumpSpeed() {
+        return maxPumpSpeed;
+    }
+
+    public @Nullable String getVspMediumPumpSpeed() {
+        return vspMediumPumpSpeed;
+    }
+
+    public @Nullable String getVspCustomPumpSpeed() {
+        return vspCustomPumpSpeed;
+    }
+
+    public @Nullable String getVspHighPumpSpeed() {
+        return vspHighPumpSpeed;
+    }
+
+    public @Nullable String getVspLowPumpSpeed() {
+        return vspLowPumpSpeed;
+    }
+
+    public List<OperationConfig> getOperations() {
+        return operations;
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Operation")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class OperationConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Action")
+        private final List<ActionConfig> actions = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<ActionConfig> getActions() {
+            return actions;
+        }
+    }
+
+    @NonNullByDefault
+    @XStreamAlias("Action")
+    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+    public static class ActionConfig {
+        private @Nullable String type;
+
+        @XStreamImplicit(itemFieldName = "Device")
+        private final List<DeviceConfig> devices = new ArrayList<>();
+
+        @XStreamImplicit(itemFieldName = "Parameter")
+        private final List<ParameterConfig> parameters = new ArrayList<>();
+
+        public @Nullable String getType() {
+            return type;
+        }
+
+        public List<DeviceConfig> getDevices() {
+            return devices;
+        }
+
+        public List<ParameterConfig> getParameters() {
+            return parameters;
+        }
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/RelayConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/RelayConfig.java
@@ -16,29 +16,41 @@ public class RelayConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
     @XStreamAsAttribute
     private @Nullable String name;
 
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String typeAttribute;
+
     @XStreamAlias("Type")
-    private @Nullable String type;
+    private @Nullable String typeElement;
+
+    @XStreamAsAttribute
+    private @Nullable String functionAttribute;
 
     @XStreamAlias("Function")
-    private @Nullable String function;
+    private @Nullable String functionElement;
 
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
     }
 
     public @Nullable String getName() {
-        return name;
+        return name != null ? name : nameElement;
     }
 
     public @Nullable String getType() {
-        return type;
+        return typeAttribute != null ? typeAttribute : typeElement;
     }
 
     public @Nullable String getFunction() {
-        return function;
+        return functionAttribute != null ? functionAttribute : functionElement;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SystemConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SystemConfig.java
@@ -16,6 +16,9 @@ public class SystemConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
     @XStreamAlias("Msp-Vsp-Speed-Format")
     private @Nullable String mspVspSpeedFormat;
 
@@ -62,7 +65,7 @@ public class SystemConfig {
     private @Nullable String uiShowSuperChlorTimeout;
 
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
     }
 
     public @Nullable String getMspVspSpeedFormat() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/VirtualHeaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/VirtualHeaterConfig.java
@@ -16,8 +16,42 @@ public class VirtualHeaterConfig {
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAlias("System-Id")
+    private @Nullable String systemIdElement;
+
+    @XStreamAsAttribute
+    private @Nullable String name;
+
+    @XStreamAlias("Name")
+    private @Nullable String nameElement;
+
+    @XStreamAsAttribute
+    private @Nullable String enable;
+
+    @XStreamAlias("Enable")
+    private @Nullable String enableElement;
+
+    @XStreamAsAttribute
+    @XStreamAlias("currentSetPoint")
+    private @Nullable String currentSetPointAttribute;
+
+    @XStreamAlias("Current-Set-Point")
+    private @Nullable String currentSetPointElement;
+
     public @Nullable String getSystemId() {
-        return systemId;
+        return systemId != null ? systemId : systemIdElement;
+    }
+
+    public @Nullable String getName() {
+        return name != null ? name : nameElement;
+    }
+
+    public @Nullable String getEnable() {
+        return enable != null ? enable : enableElement;
+    }
+
+    public @Nullable String getCurrentSetPoint() {
+        return currentSetPointAttribute != null ? currentSetPointAttribute : currentSetPointElement;
     }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -46,10 +46,64 @@ public class ConfigParserTest {
                 "      <Spillover-Timed-Timeout>20</Spillover-Timed-Timeout>" +
                 "      <Freeze-Protect-Override>no</Freeze-Protect-Override>" +
                 "      <Size-In-Gallons>15000</Size-In-Gallons>" +
-                "      <Filter systemId='F1' pumpId='P1'/>" +
-                "      <Heater systemId='H1' type='gas'/>" +
-                "      <Chlorinator systemId='C1'/>" +
-                "      <ColorLogic-Light systemId='L1'/>" +
+                "      <Filter systemId='F1' pumpId='P1'>" +
+                "        <Name>Filter Pump</Name>" +
+                "        <Shared-Type>BOW_SHARED_EQUIPMENT</Shared-Type>" +
+                "        <Filter-Type>FMT_VARIABLE_SPEED_PUMP</Filter-Type>" +
+                "        <Max-Pump-Speed>100</Max-Pump-Speed>" +
+                "        <Min-Pump-Speed>18</Min-Pump-Speed>" +
+                "        <Max-Pump-RPM>3450</Max-Pump-RPM>" +
+                "        <Min-Pump-RPM>600</Min-Pump-RPM>" +
+                "        <Vsp-Low-Pump-Speed>18</Vsp-Low-Pump-Speed>" +
+                "        <Vsp-Medium-Pump-Speed>50</Vsp-Medium-Pump-Speed>" +
+                "        <Vsp-High-Pump-Speed>100</Vsp-High-Pump-Speed>" +
+                "        <Vsp-Custom-Pump-Speed>80</Vsp-Custom-Pump-Speed>" +
+                "        <Operation>PEO_FILTER_SAMPLE" +
+                "          <Action>PEA_FILTER_SPEED" +
+                "            <Parameter name='Speed' dataType='int'>3200</Parameter>" +
+                "          </Action>" +
+                "        </Operation>" +
+                "      </Filter>" +
+                "      <Heater systemId='H1' type='gas' sharedType='BOW_SHARED_EQUIPMENT' enabled='yes' currentSetPoint='80'>" +
+                "        <Shared-Type>BOW_SHARED_EQUIPMENT</Shared-Type>" +
+                "        <Enabled>yes</Enabled>" +
+                "        <Current-Set-Point>82</Current-Set-Point>" +
+                "        <Max-Water-Temp>104</Max-Water-Temp>" +
+                "        <Min-Settable-Water-Temp>65</Min-Settable-Water-Temp>" +
+                "        <Max-Settable-Water-Temp>104</Max-Settable-Water-Temp>" +
+                "        <Cooldown-Enabled>no</Cooldown-Enabled>" +
+                "        <Operation>PEO_HEATER_EQUIPMENT" +
+                "          <Heater-Equipment>" +
+                "            <System-Id>HX1</System-Id>" +
+                "            <Name>Gas Heater</Name>" +
+                "            <Type>PET_HEATER</Type>" +
+                "            <Heater-Type>HTR_GAS</Heater-Type>" +
+                "            <Enabled>yes</Enabled>" +
+                "          </Heater-Equipment>" +
+                "        </Operation>" +
+                "        <Operation>PEO_HEATER_FLOW" +
+                "          <Action>PEA_FLOW" +
+                "            <Parameter name='Flow' dataType='int'>40</Parameter>" +
+                "          </Action>" +
+                "        </Operation>" +
+                "      </Heater>" +
+                "      <Chlorinator systemId='C1' sharedType='BOW_SHARED_EQUIPMENT' enabled='yes'>" +
+                "        <Name>Chlorinator</Name>" +
+                "        <Mode>CHLOR_OP_MODE_ORP_AUTO</Mode>" +
+                "        <Timed-Percent>50</Timed-Percent>" +
+                "        <SuperChlor-Timeout>24</SuperChlor-Timeout>" +
+                "        <Cell-Type>CELL_TYPE_T15</Cell-Type>" +
+                "        <ORP-Timeout>86400</ORP-Timeout>" +
+                "        <Operation>PEO_CHLOR_SAMPLE" +
+                "          <Action>PEA_SET_PERCENT" +
+                "            <Parameter name='Percent' dataType='int'>60</Parameter>" +
+                "          </Action>" +
+                "        </Operation>" +
+                "      </Chlorinator>" +
+                "      <ColorLogic-Light systemId='L1'>" +
+                "        <Name>Pool Light</Name>" +
+                "        <Type>COLOR_LOGIC_UCL</Type>" +
+                "      </ColorLogic-Light>" +
                 "      <Relay systemId='R1' name='Aux1'>" +
                 "        <Type>RLY_HIGH_VOLTAGE_RELAY</Type>" +
                 "        <Function>GENERIC</Function>" +
@@ -61,8 +115,27 @@ public class ConfigParserTest {
                 "        <Units>UNITS_FAHRENHEIT</Units>" +
                 "      </Sensor>" +
                 "    </BodyOfWater>" +
-                "    <Pump systemId='P1' name='Main'/>" +
-                "    <VirtualHeater systemId='VH1'/>" +
+                "    <Pump systemId='P1' name='Main'>" +
+                "      <Type>PMP_VARIABLE_SPEED_PUMP</Type>" +
+                "      <Function>PMP_FILTER</Function>" +
+                "      <Max-Pump-RPM>3450</Max-Pump-RPM>" +
+                "      <Min-Pump-RPM>600</Min-Pump-RPM>" +
+                "      <Min-Pump-Speed>20</Min-Pump-Speed>" +
+                "      <Max-Pump-Speed>100</Max-Pump-Speed>" +
+                "      <Vsp-Medium-Pump-Speed>60</Vsp-Medium-Pump-Speed>" +
+                "      <Vsp-Custom-Pump-Speed>70</Vsp-Custom-Pump-Speed>" +
+                "      <Vsp-High-Pump-Speed>100</Vsp-High-Pump-Speed>" +
+                "      <Vsp-Low-Pump-Speed>30</Vsp-Low-Pump-Speed>" +
+                "      <Operation>PEO_PUMP_SAMPLE" +
+                "        <Action>PEA_SET_SPEED" +
+                "          <Parameter name='Speed' dataType='int'>3100</Parameter>" +
+                "        </Action>" +
+                "      </Operation>" +
+                "    </Pump>" +
+                "    <VirtualHeater systemId='VH1' name='Spa Heat' enable='yes' currentSetPoint='90'>" +
+                "      <Enable>yes</Enable>" +
+                "      <Current-Set-Point>92</Current-Set-Point>" +
+                "    </VirtualHeater>" +
                 "  </Backyard>" +
                 "  <Schedules>" +
                 "    <Schedule systemId='SCH1' name='Filter' type='equipment'>" +
@@ -132,17 +205,87 @@ public class ConfigParserTest {
         FilterConfig filter = bow.getFilters().get(0);
         assertEquals("F1", filter.getSystemId());
         assertEquals("P1", filter.getPumpId());
+        assertEquals("Filter Pump", filter.getName());
+        assertEquals("BOW_SHARED_EQUIPMENT", filter.getSharedType());
+        assertEquals("FMT_VARIABLE_SPEED_PUMP", filter.getFilterType());
+        assertEquals("100", filter.getMaxPumpSpeed());
+        assertEquals("18", filter.getMinPumpSpeed());
+        assertEquals("3450", filter.getMaxPumpRpm());
+        assertEquals("600", filter.getMinPumpRpm());
+        assertEquals("18", filter.getVspLowPumpSpeed());
+        assertEquals("50", filter.getVspMediumPumpSpeed());
+        assertEquals("100", filter.getVspHighPumpSpeed());
+        assertEquals("80", filter.getVspCustomPumpSpeed());
+        assertEquals(1, filter.getOperations().size());
+        FilterConfig.OperationConfig filterOperation = filter.getOperations().get(0);
+        assertEquals("PEO_FILTER_SAMPLE", filterOperation.getType());
+        assertEquals(1, filterOperation.getActions().size());
+        FilterConfig.ActionConfig filterAction = filterOperation.getActions().get(0);
+        assertEquals("PEA_FILTER_SPEED", filterAction.getType());
+        assertEquals(0, filterAction.getDevices().size());
+        assertEquals(1, filterAction.getParameters().size());
+        assertEquals("Speed", filterAction.getParameters().get(0).getName());
+        assertEquals("3200", filterAction.getParameters().get(0).getValue());
 
         assertEquals(1, bow.getHeaters().size());
         HeaterConfig heater = bow.getHeaters().get(0);
         assertEquals("H1", heater.getSystemId());
         assertEquals("gas", heater.getType());
+        assertEquals("BOW_SHARED_EQUIPMENT", heater.getSharedType());
+        assertEquals("yes", heater.getEnabled());
+        assertEquals("80", heater.getCurrentSetPoint());
+        assertEquals("104", heater.getMaxWaterTemp());
+        assertEquals("65", heater.getMinSettableWaterTemp());
+        assertEquals("104", heater.getMaxSettableWaterTemp());
+        assertEquals("no", heater.getCooldownEnabled());
+        assertEquals(2, heater.getOperations().size());
+        HeaterConfig.OperationConfig heaterEquipmentOp = heater.getOperations().get(0);
+        assertEquals("PEO_HEATER_EQUIPMENT", heaterEquipmentOp.getType());
+        assertEquals(0, heaterEquipmentOp.getActions().size());
+        assertEquals(1, heaterEquipmentOp.getHeaterEquipment().size());
+        HeaterConfig.HeaterEquipmentConfig heaterEquipment = heaterEquipmentOp.getHeaterEquipment().get(0);
+        assertEquals("HX1", heaterEquipment.getSystemId());
+        assertEquals("Gas Heater", heaterEquipment.getName());
+        assertEquals("PET_HEATER", heaterEquipment.getType());
+        assertEquals("HTR_GAS", heaterEquipment.getHeaterType());
+        assertEquals("yes", heaterEquipment.getEnabled());
+        HeaterConfig.OperationConfig heaterFlowOp = heater.getOperations().get(1);
+        assertEquals("PEO_HEATER_FLOW", heaterFlowOp.getType());
+        assertEquals(1, heaterFlowOp.getActions().size());
+        HeaterConfig.ActionConfig heaterFlowAction = heaterFlowOp.getActions().get(0);
+        assertEquals("PEA_FLOW", heaterFlowAction.getType());
+        assertEquals(0, heaterFlowAction.getDevices().size());
+        assertEquals(1, heaterFlowAction.getParameters().size());
+        assertEquals("Flow", heaterFlowAction.getParameters().get(0).getName());
+        assertEquals("40", heaterFlowAction.getParameters().get(0).getValue());
 
         assertEquals(1, bow.getChlorinators().size());
-        assertEquals("C1", bow.getChlorinators().get(0).getSystemId());
+        ChlorinatorConfig chlorinator = bow.getChlorinators().get(0);
+        assertEquals("C1", chlorinator.getSystemId());
+        assertEquals("Chlorinator", chlorinator.getName());
+        assertEquals("BOW_SHARED_EQUIPMENT", chlorinator.getSharedType());
+        assertEquals("yes", chlorinator.getEnabled());
+        assertEquals("CHLOR_OP_MODE_ORP_AUTO", chlorinator.getMode());
+        assertEquals("50", chlorinator.getTimedPercent());
+        assertEquals("24", chlorinator.getSuperChlorTimeout());
+        assertEquals("CELL_TYPE_T15", chlorinator.getCellType());
+        assertEquals("86400", chlorinator.getOrpTimeout());
+        assertEquals(1, chlorinator.getOperations().size());
+        ChlorinatorConfig.OperationConfig chlorinatorOp = chlorinator.getOperations().get(0);
+        assertEquals("PEO_CHLOR_SAMPLE", chlorinatorOp.getType());
+        assertEquals(1, chlorinatorOp.getActions().size());
+        ChlorinatorConfig.ActionConfig chlorinatorAction = chlorinatorOp.getActions().get(0);
+        assertEquals("PEA_SET_PERCENT", chlorinatorAction.getType());
+        assertEquals(0, chlorinatorAction.getDevices().size());
+        assertEquals(1, chlorinatorAction.getParameters().size());
+        assertEquals("Percent", chlorinatorAction.getParameters().get(0).getName());
+        assertEquals("60", chlorinatorAction.getParameters().get(0).getValue());
 
         assertEquals(1, bow.getColorLogicLights().size());
-        assertEquals("L1", bow.getColorLogicLights().get(0).getSystemId());
+        ColorLogicLightConfig light = bow.getColorLogicLights().get(0);
+        assertEquals("L1", light.getSystemId());
+        assertEquals("Pool Light", light.getName());
+        assertEquals("COLOR_LOGIC_UCL", light.getType());
 
         assertEquals(1, bow.getRelays().size());
         RelayConfig relay = bow.getRelays().get(0);
@@ -160,9 +303,33 @@ public class ConfigParserTest {
         PumpConfig pump = backyard.getPumps().get(0);
         assertEquals("P1", pump.getSystemId());
         assertEquals("Main", pump.getName());
+        assertEquals("PMP_VARIABLE_SPEED_PUMP", pump.getType());
+        assertEquals("PMP_FILTER", pump.getFunction());
+        assertEquals("3450", pump.getMaxPumpRpm());
+        assertEquals("600", pump.getMinPumpRpm());
+        assertEquals("20", pump.getMinPumpSpeed());
+        assertEquals("100", pump.getMaxPumpSpeed());
+        assertEquals("60", pump.getVspMediumPumpSpeed());
+        assertEquals("70", pump.getVspCustomPumpSpeed());
+        assertEquals("100", pump.getVspHighPumpSpeed());
+        assertEquals("30", pump.getVspLowPumpSpeed());
+        assertEquals(1, pump.getOperations().size());
+        PumpConfig.OperationConfig pumpOperation = pump.getOperations().get(0);
+        assertEquals("PEO_PUMP_SAMPLE", pumpOperation.getType());
+        assertEquals(1, pumpOperation.getActions().size());
+        PumpConfig.ActionConfig pumpAction = pumpOperation.getActions().get(0);
+        assertEquals("PEA_SET_SPEED", pumpAction.getType());
+        assertEquals(0, pumpAction.getDevices().size());
+        assertEquals(1, pumpAction.getParameters().size());
+        assertEquals("Speed", pumpAction.getParameters().get(0).getName());
+        assertEquals("3100", pumpAction.getParameters().get(0).getValue());
 
         assertEquals(1, backyard.getVirtualHeaters().size());
-        assertEquals("VH1", backyard.getVirtualHeaters().get(0).getSystemId());
+        VirtualHeaterConfig virtualHeater = backyard.getVirtualHeaters().get(0);
+        assertEquals("VH1", virtualHeater.getSystemId());
+        assertEquals("Spa Heat", virtualHeater.getName());
+        assertEquals("yes", virtualHeater.getEnable());
+        assertEquals("90", virtualHeater.getCurrentSetPoint());
 
         assertEquals(1, config.getSchedules().size());
         ScheduleConfig schedule = config.getSchedules().get(0);


### PR DESCRIPTION
## Summary
- expand pump, filter, heater, and chlorinator configs to capture scalar values and nested operations/actions from MSP XML
- add support for element-based IDs plus names/types on ColorLogic, relay, and virtual heater configs
- grow ConfigParserTest XML fixture to cover new getters and operation/action parsing

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am test *(fails: parent POM org.openhab:openhab-super-pom unavailable without internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b37f1e9c8323a7679871dd7f770c