### PR TITLE
Refactor operation parsing

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfig.java
@@ -1,0 +1,47 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
+
+/**
+ * Representation of an Action element.
+ */
+@NonNullByDefault
+@XStreamAlias("Action")
+@XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+public class ActionConfig {
+    private @Nullable String type;
+
+    @XStreamImplicit(itemFieldName = "Device")
+    private final List<DeviceConfig> devices = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Parameter")
+    private final List<ParameterConfig> parameters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Operation")
+    private final List<OperationConfig> operations = new ArrayList<>();
+
+    public @Nullable String getType() {
+        return type;
+    }
+
+    public List<DeviceConfig> getDevices() {
+        return devices;
+    }
+
+    public List<ParameterConfig> getParameters() {
+        return parameters;
+    }
+
+    public List<OperationConfig> getOperations() {
+        return operations;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ChlorinatorConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ChlorinatorConfig.java
@@ -9,8 +9,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Chlorinator element.
@@ -102,47 +100,5 @@ public class ChlorinatorConfig {
         return operations;
     }
 
-    @NonNullByDefault
-    @XStreamAlias("Operation")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class OperationConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Action")
-        private final List<ActionConfig> actions = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<ActionConfig> getActions() {
-            return actions;
-        }
-    }
-
-    @NonNullByDefault
-    @XStreamAlias("Action")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class ActionConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Device")
-        private final List<DeviceConfig> devices = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Parameter")
-        private final List<ParameterConfig> parameters = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<DeviceConfig> getDevices() {
-            return devices;
-        }
-
-        public List<ParameterConfig> getParameters() {
-            return parameters;
-        }
-    }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParser.java
@@ -18,10 +18,11 @@ public final class ConfigParser {
         XSTREAM.ignoreUnknownElements();
         XSTREAM.addPermission(AnyTypePermission.ANY);
         XSTREAM.processAnnotations(new Class<?>[] { MspConfig.class, SystemConfig.class, BackyardConfig.class,
-                BodyOfWaterConfig.class, PumpConfig.class, FilterConfig.class, HeaterConfig.class, SensorConfig.class,
-                VirtualHeaterConfig.class, ChlorinatorConfig.class, ColorLogicLightConfig.class, RelayConfig.class,
-                SchedulesConfig.class, ScheduleConfig.class, ScheduleActionConfig.class, DeviceConfig.class,
-                ParameterConfig.class, DmtConfig.class });
+                BodyOfWaterConfig.class, PumpConfig.class, FilterConfig.class, HeaterConfig.class,
+                HeaterConfig.HeaterEquipmentConfig.class, SensorConfig.class, VirtualHeaterConfig.class,
+                ChlorinatorConfig.class, ColorLogicLightConfig.class, RelayConfig.class, OperationConfig.class,
+                ActionConfig.class, SchedulesConfig.class, ScheduleConfig.class, ScheduleActionConfig.class,
+                DeviceConfig.class, ParameterConfig.class, DmtConfig.class });
     }
 
     private ConfigParser() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/FilterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/FilterConfig.java
@@ -9,8 +9,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Filter element.
@@ -135,47 +133,5 @@ public class FilterConfig {
         return operations;
     }
 
-    @NonNullByDefault
-    @XStreamAlias("Operation")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class OperationConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Action")
-        private final List<ActionConfig> actions = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<ActionConfig> getActions() {
-            return actions;
-        }
-    }
-
-    @NonNullByDefault
-    @XStreamAlias("Action")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class ActionConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Device")
-        private final List<DeviceConfig> devices = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Parameter")
-        private final List<ParameterConfig> parameters = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<DeviceConfig> getDevices() {
-            return devices;
-        }
-
-        public List<ParameterConfig> getParameters() {
-            return parameters;
-        }
-    }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HeaterConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/HeaterConfig.java
@@ -9,8 +9,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Heater element.
@@ -104,56 +102,6 @@ public class HeaterConfig {
 
     public List<OperationConfig> getOperations() {
         return operations;
-    }
-
-    @NonNullByDefault
-    @XStreamAlias("Operation")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class OperationConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Action")
-        private final List<ActionConfig> actions = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Heater-Equipment")
-        private final List<HeaterEquipmentConfig> heaterEquipment = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<ActionConfig> getActions() {
-            return actions;
-        }
-
-        public List<HeaterEquipmentConfig> getHeaterEquipment() {
-            return heaterEquipment;
-        }
-    }
-
-    @NonNullByDefault
-    @XStreamAlias("Action")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class ActionConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Device")
-        private final List<DeviceConfig> devices = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Parameter")
-        private final List<ParameterConfig> parameters = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<DeviceConfig> getDevices() {
-            return devices;
-        }
-
-        public List<ParameterConfig> getParameters() {
-            return parameters;
-        }
     }
 
     @NonNullByDefault

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/OperationConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/OperationConfig.java
@@ -1,0 +1,56 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import org.openhab.binding.haywardomnilogiclocal.internal.config.HeaterConfig.HeaterEquipmentConfig;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
+
+/**
+ * Representation of an Operation element.
+ */
+@NonNullByDefault
+@XStreamAlias("Operation")
+@XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+public class OperationConfig {
+    private @Nullable String type;
+
+    @XStreamImplicit(itemFieldName = "Action")
+    private final List<ActionConfig> actions = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Operation")
+    private final List<OperationConfig> operations = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Parameter")
+    private final List<ParameterConfig> parameters = new ArrayList<>();
+
+    @XStreamImplicit(itemFieldName = "Heater-Equipment")
+    private final List<HeaterEquipmentConfig> heaterEquipment = new ArrayList<>();
+
+    public @Nullable String getType() {
+        return type;
+    }
+
+    public List<ActionConfig> getActions() {
+        return actions;
+    }
+
+    public List<OperationConfig> getOperations() {
+        return operations;
+    }
+
+    public List<ParameterConfig> getParameters() {
+        return parameters;
+    }
+
+    public List<HeaterEquipmentConfig> getHeaterEquipment() {
+        return heaterEquipment;
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/PumpConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/PumpConfig.java
@@ -9,8 +9,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
-import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Pump element.
@@ -122,47 +120,5 @@ public class PumpConfig {
         return operations;
     }
 
-    @NonNullByDefault
-    @XStreamAlias("Operation")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class OperationConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Action")
-        private final List<ActionConfig> actions = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<ActionConfig> getActions() {
-            return actions;
-        }
-    }
-
-    @NonNullByDefault
-    @XStreamAlias("Action")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class ActionConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Device")
-        private final List<DeviceConfig> devices = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Parameter")
-        private final List<ParameterConfig> parameters = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<DeviceConfig> getDevices() {
-            return devices;
-        }
-
-        public List<ParameterConfig> getParameters() {
-            return parameters;
-        }
-    }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SensorConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SensorConfig.java
@@ -8,9 +8,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import com.thoughtworks.xstream.annotations.XStreamConverter;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of a Sensor element.
@@ -66,54 +64,5 @@ public class SensorConfig {
         return operations;
     }
 
-    @NonNullByDefault
-    @XStreamAlias("Operation")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class OperationConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Action")
-        private final List<ActionConfig> actions = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Parameter")
-        private final List<ParameterConfig> parameters = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<ActionConfig> getActions() {
-            return actions;
-        }
-
-        public List<ParameterConfig> getParameters() {
-            return parameters;
-        }
-    }
-
-    @NonNullByDefault
-    @XStreamAlias("Action")
-    @XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
-    public static class ActionConfig {
-        private @Nullable String type;
-
-        @XStreamImplicit(itemFieldName = "Device")
-        private final List<DeviceConfig> devices = new ArrayList<>();
-
-        @XStreamImplicit(itemFieldName = "Parameter")
-        private final List<ParameterConfig> parameters = new ArrayList<>();
-
-        public @Nullable String getType() {
-            return type;
-        }
-
-        public List<DeviceConfig> getDevices() {
-            return devices;
-        }
-
-        public List<ParameterConfig> getParameters() {
-            return parameters;
-        }
-    }
 }
 

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -120,6 +120,7 @@ public class ConfigParserTest {
                 "        <Type>SENSOR_WATER_TEMP</Type>" +
                 "        <Units>UNITS_FAHRENHEIT</Units>" +
                 "        <Operation>PEO_SENSOR_SAMPLE" +
+                "          <Parameter name='SampleRate' dataType='int'>5</Parameter>" +
                 "          <Action>PEA_SENSOR_REPORT" +
                 "            <Parameter name='Interval' dataType='int'>15</Parameter>" +
                 "          </Action>" +
@@ -141,6 +142,11 @@ public class ConfigParserTest {
                 "        <Action>PEA_SET_SPEED" +
                 "          <Parameter name='Speed' dataType='int'>3100</Parameter>" +
                 "        </Action>" +
+                "        <Operation>PEO_PUMP_CHILD" +
+                "          <Action>PEA_CHILD_SPEED" +
+                "            <Parameter name='Speed' dataType='int'>2800</Parameter>" +
+                "          </Action>" +
+                "        </Operation>" +
                 "      </Operation>" +
                 "    </Pump>" +
                 "    <VirtualHeater systemId='VH1' name='Spa Heat' enable='yes' currentSetPoint='90'>" +
@@ -235,10 +241,10 @@ public class ConfigParserTest {
         assertEquals("100", filter.getVspHighPumpSpeed());
         assertEquals("80", filter.getVspCustomPumpSpeed());
         assertEquals(1, filter.getOperations().size());
-        FilterConfig.OperationConfig filterOperation = filter.getOperations().get(0);
+        OperationConfig filterOperation = filter.getOperations().get(0);
         assertEquals("PEO_FILTER_SAMPLE", filterOperation.getType());
         assertEquals(1, filterOperation.getActions().size());
-        FilterConfig.ActionConfig filterAction = filterOperation.getActions().get(0);
+        ActionConfig filterAction = filterOperation.getActions().get(0);
         assertEquals("PEA_FILTER_SPEED", filterAction.getType());
         assertEquals(0, filterAction.getDevices().size());
         assertEquals(1, filterAction.getParameters().size());
@@ -257,7 +263,7 @@ public class ConfigParserTest {
         assertEquals("104", heater.getMaxSettableWaterTemp());
         assertEquals("no", heater.getCooldownEnabled());
         assertEquals(2, heater.getOperations().size());
-        HeaterConfig.OperationConfig heaterEquipmentOp = heater.getOperations().get(0);
+        OperationConfig heaterEquipmentOp = heater.getOperations().get(0);
         assertEquals("PEO_HEATER_EQUIPMENT", heaterEquipmentOp.getType());
         assertEquals(0, heaterEquipmentOp.getActions().size());
         assertEquals(1, heaterEquipmentOp.getHeaterEquipment().size());
@@ -267,10 +273,10 @@ public class ConfigParserTest {
         assertEquals("PET_HEATER", heaterEquipment.getType());
         assertEquals("HTR_GAS", heaterEquipment.getHeaterType());
         assertEquals("yes", heaterEquipment.getEnabled());
-        HeaterConfig.OperationConfig heaterFlowOp = heater.getOperations().get(1);
+        OperationConfig heaterFlowOp = heater.getOperations().get(1);
         assertEquals("PEO_HEATER_FLOW", heaterFlowOp.getType());
         assertEquals(1, heaterFlowOp.getActions().size());
-        HeaterConfig.ActionConfig heaterFlowAction = heaterFlowOp.getActions().get(0);
+        ActionConfig heaterFlowAction = heaterFlowOp.getActions().get(0);
         assertEquals("PEA_FLOW", heaterFlowAction.getType());
         assertEquals(0, heaterFlowAction.getDevices().size());
         assertEquals(1, heaterFlowAction.getParameters().size());
@@ -289,10 +295,10 @@ public class ConfigParserTest {
         assertEquals("CELL_TYPE_T15", chlorinator.getCellType());
         assertEquals("86400", chlorinator.getOrpTimeout());
         assertEquals(1, chlorinator.getOperations().size());
-        ChlorinatorConfig.OperationConfig chlorinatorOp = chlorinator.getOperations().get(0);
+        OperationConfig chlorinatorOp = chlorinator.getOperations().get(0);
         assertEquals("PEO_CHLOR_SAMPLE", chlorinatorOp.getType());
         assertEquals(1, chlorinatorOp.getActions().size());
-        ChlorinatorConfig.ActionConfig chlorinatorAction = chlorinatorOp.getActions().get(0);
+        ActionConfig chlorinatorAction = chlorinatorOp.getActions().get(0);
         assertEquals("PEA_SET_PERCENT", chlorinatorAction.getType());
         assertEquals(0, chlorinatorAction.getDevices().size());
         assertEquals(1, chlorinatorAction.getParameters().size());
@@ -317,10 +323,14 @@ public class ConfigParserTest {
         assertEquals("SENSOR_WATER_TEMP", sensor.getType());
         assertEquals("UNITS_FAHRENHEIT", sensor.getUnits());
         assertEquals(1, sensor.getOperations().size());
-        SensorConfig.OperationConfig sensorOperation = sensor.getOperations().get(0);
+        OperationConfig sensorOperation = sensor.getOperations().get(0);
         assertEquals("PEO_SENSOR_SAMPLE", sensorOperation.getType());
+        assertEquals(1, sensorOperation.getParameters().size());
+        ParameterConfig sensorOperationParameter = sensorOperation.getParameters().get(0);
+        assertEquals("SampleRate", sensorOperationParameter.getName());
+        assertEquals("5", sensorOperationParameter.getValue());
         assertEquals(1, sensorOperation.getActions().size());
-        SensorConfig.ActionConfig sensorAction = sensorOperation.getActions().get(0);
+        ActionConfig sensorAction = sensorOperation.getActions().get(0);
         assertEquals("PEA_SENSOR_REPORT", sensorAction.getType());
         assertEquals(0, sensorAction.getDevices().size());
         assertEquals(1, sensorAction.getParameters().size());
@@ -342,15 +352,24 @@ public class ConfigParserTest {
         assertEquals("100", pump.getVspHighPumpSpeed());
         assertEquals("30", pump.getVspLowPumpSpeed());
         assertEquals(1, pump.getOperations().size());
-        PumpConfig.OperationConfig pumpOperation = pump.getOperations().get(0);
+        OperationConfig pumpOperation = pump.getOperations().get(0);
         assertEquals("PEO_PUMP_SAMPLE", pumpOperation.getType());
         assertEquals(1, pumpOperation.getActions().size());
-        PumpConfig.ActionConfig pumpAction = pumpOperation.getActions().get(0);
+        ActionConfig pumpAction = pumpOperation.getActions().get(0);
         assertEquals("PEA_SET_SPEED", pumpAction.getType());
         assertEquals(0, pumpAction.getDevices().size());
         assertEquals(1, pumpAction.getParameters().size());
         assertEquals("Speed", pumpAction.getParameters().get(0).getName());
         assertEquals("3100", pumpAction.getParameters().get(0).getValue());
+        assertEquals(1, pumpOperation.getOperations().size());
+        OperationConfig nestedPumpOperation = pumpOperation.getOperations().get(0);
+        assertEquals("PEO_PUMP_CHILD", nestedPumpOperation.getType());
+        assertEquals(1, nestedPumpOperation.getActions().size());
+        ActionConfig nestedPumpAction = nestedPumpOperation.getActions().get(0);
+        assertEquals("PEA_CHILD_SPEED", nestedPumpAction.getType());
+        assertEquals(1, nestedPumpAction.getParameters().size());
+        assertEquals("Speed", nestedPumpAction.getParameters().get(0).getName());
+        assertEquals("2800", nestedPumpAction.getParameters().get(0).getValue());
 
         assertEquals(1, backyard.getVirtualHeaters().size());
         VirtualHeaterConfig virtualHeater = backyard.getVirtualHeaters().get(0);


### PR DESCRIPTION
## Summary
- add shared OperationConfig and ActionConfig representations for <Operation>/<Action> XML nodes
- update equipment and sensor configurations to use the shared operation/action lists and register them with the parser
- extend the parser test to cover nested operations and operation-level parameters

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal test *(fails: missing parent POM due to offline Maven repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c94b858fd8832385a57dd892fb384a