### PR TITLE
Support sche schedule elements in Hayward OmniLogic config parsing

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ScheduleConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ScheduleConfig.java
@@ -14,14 +14,21 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * Representation of a single schedule entry.
  */
 @NonNullByDefault
-@XStreamAlias("Schedule")
+@XStreamAlias("sche")
 public class ScheduleConfig {
     @XStreamAsAttribute
     @XStreamAlias("systemId")
     private @Nullable String systemId;
 
+    @XStreamAsAttribute
+    @XStreamAlias("system-id")
+    private @Nullable String systemIdHyphen;
+
     @XStreamAlias("System-Id")
     private @Nullable String systemIdElement;
+
+    @XStreamAlias("system-id")
+    private @Nullable String systemIdElementLower;
 
     @XStreamAsAttribute
     private @Nullable String name;
@@ -29,17 +36,30 @@ public class ScheduleConfig {
     @XStreamAlias("Name")
     private @Nullable String nameElement;
 
+    @XStreamAlias("name")
+    private @Nullable String nameElementLower;
+
     @XStreamAsAttribute
     private @Nullable String type;
 
     @XStreamAlias("Type")
     private @Nullable String typeElement;
 
+    @XStreamAlias("type")
+    private @Nullable String typeElementLower;
+
     @XStreamAsAttribute
     private @Nullable String subType;
 
+    @XStreamAsAttribute
+    @XStreamAlias("sub-type")
+    private @Nullable String subTypeHyphen;
+
     @XStreamAlias("Sub-Type")
     private @Nullable String subTypeElement;
+
+    @XStreamAlias("sub-type")
+    private @Nullable String subTypeElementLower;
 
     @XStreamAsAttribute
     private @Nullable String enabled;
@@ -47,33 +67,84 @@ public class ScheduleConfig {
     @XStreamAlias("Enabled")
     private @Nullable String enabledElement;
 
+    @XStreamAlias("enabled")
+    private @Nullable String enabledElementLower;
+
     @XStreamImplicit(itemFieldName = "Device")
     private final List<DeviceConfig> devices = new ArrayList<>();
+
+    @SuppressWarnings("unused")
+    @XStreamImplicit(itemFieldName = "device")
+    private final List<DeviceConfig> lowercaseDevices = devices;
 
     @XStreamImplicit(itemFieldName = "Parameter")
     private final List<ParameterConfig> parameters = new ArrayList<>();
 
+    @SuppressWarnings("unused")
+    @XStreamImplicit(itemFieldName = "parameter")
+    private final List<ParameterConfig> lowercaseParameters = parameters;
+
     @XStreamImplicit(itemFieldName = "Action")
     private final List<ScheduleActionConfig> actions = new ArrayList<>();
 
+    @SuppressWarnings("unused")
+    @XStreamImplicit(itemFieldName = "action")
+    private final List<ScheduleActionConfig> lowercaseActions = actions;
+
     public @Nullable String getSystemId() {
-        return systemId != null ? systemId : systemIdElement;
+        if (systemId != null) {
+            return systemId;
+        }
+        if (systemIdHyphen != null) {
+            return systemIdHyphen;
+        }
+        if (systemIdElement != null) {
+            return systemIdElement;
+        }
+        return systemIdElementLower;
     }
 
     public @Nullable String getName() {
-        return name != null ? name : nameElement;
+        if (name != null) {
+            return name;
+        }
+        if (nameElement != null) {
+            return nameElement;
+        }
+        return nameElementLower;
     }
 
     public @Nullable String getType() {
-        return type != null ? type : typeElement;
+        if (type != null) {
+            return type;
+        }
+        if (typeElement != null) {
+            return typeElement;
+        }
+        return typeElementLower;
     }
 
     public @Nullable String getSubType() {
-        return subType != null ? subType : subTypeElement;
+        if (subType != null) {
+            return subType;
+        }
+        if (subTypeHyphen != null) {
+            return subTypeHyphen;
+        }
+        if (subTypeElement != null) {
+            return subTypeElement;
+        }
+        return subTypeElementLower;
     }
 
     public @Nullable String getEnabled() {
-        return enabled != null ? enabled : enabledElement;
+        if (enabled != null) {
+            return enabled;
+        }
+        if (enabledElement != null) {
+            return enabledElement;
+        }
+        return enabledElementLower;
     }
 
     public List<DeviceConfig> getDevices() {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SchedulesConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/SchedulesConfig.java
@@ -14,8 +14,12 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @NonNullByDefault
 @XStreamAlias("Schedules")
 public class SchedulesConfig {
-    @XStreamImplicit(itemFieldName = "Schedule")
+    @XStreamImplicit(itemFieldName = "sche")
     private final List<ScheduleConfig> schedules = new ArrayList<>();
+
+    @SuppressWarnings("unused")
+    @XStreamImplicit(itemFieldName = "Schedule")
+    private final List<ScheduleConfig> legacySchedules = schedules;
 
     public List<ScheduleConfig> getSchedules() {
         return schedules;

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -277,9 +277,50 @@ public class ConfigParserTest {
         assertEquals("1", nestedOperation.getParameters().get(0).getValue());
     }
 
+    @Test
+    public void testParseSchedulesWithScheElements() throws IOException {
+        MspConfig config = parseConfigurationResource("request-configuration-msp-sample.xml");
+
+        assertEquals(2, config.getSchedules().size());
+
+        ScheduleConfig firstSchedule = config.getSchedules().get(0);
+        assertEquals("SCH1", firstSchedule.getSystemId());
+        assertEquals("Filter Schedule", firstSchedule.getName());
+        assertEquals("equipment", firstSchedule.getType());
+        assertEquals("pump", firstSchedule.getSubType());
+        assertEquals("yes", firstSchedule.getEnabled());
+        assertEquals(1, firstSchedule.getDevices().size());
+        assertEquals("P1", firstSchedule.getDevices().get(0).getSystemId());
+        assertEquals(1, firstSchedule.getParameters().size());
+        assertEquals("StartTimeHours", firstSchedule.getParameters().get(0).getName());
+        assertEquals("6", firstSchedule.getParameters().get(0).getValue());
+        assertEquals(1, firstSchedule.getActions().size());
+        ScheduleActionConfig firstAction = firstSchedule.getActions().get(0);
+        assertEquals("on", firstAction.getType());
+        assertEquals(1, firstAction.getParameters().size());
+        assertEquals("Duration", firstAction.getParameters().get(0).getName());
+        assertEquals("30", firstAction.getParameters().get(0).getValue());
+
+        ScheduleConfig secondSchedule = config.getSchedules().get(1);
+        assertEquals("SCH2", secondSchedule.getSystemId());
+        assertEquals("Chlorinator", secondSchedule.getName());
+        assertEquals("equipment", secondSchedule.getType());
+        assertEquals("chlorinator", secondSchedule.getSubType());
+        assertEquals("no", secondSchedule.getEnabled());
+        assertEquals(0, secondSchedule.getDevices().size());
+        assertEquals(1, secondSchedule.getParameters().size());
+        assertEquals("StartTimeHours", secondSchedule.getParameters().get(0).getName());
+        assertEquals("2", secondSchedule.getParameters().get(0).getValue());
+        assertEquals(0, secondSchedule.getActions().size());
+    }
+
     private static MspConfig parseSampleConfiguration() throws IOException {
-        try (InputStream stream = ConfigParserTest.class.getResourceAsStream("request-configuration-sample.xml")) {
-            assertNotNull(stream, "Sample RequestConfiguration XML is missing");
+        return parseConfigurationResource("request-configuration-sample.xml");
+    }
+
+    private static MspConfig parseConfigurationResource(String resourceName) throws IOException {
+        try (InputStream stream = ConfigParserTest.class.getResourceAsStream(resourceName)) {
+            assertNotNull(stream, "Sample RequestConfiguration XML is missing: " + resourceName);
             String xml = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return ConfigParser.parse(xml);
         }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/resources/org/openhab/binding/haywardomnilogiclocal/internal/config/request-configuration-msp-sample.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/resources/org/openhab/binding/haywardomnilogiclocal/internal/config/request-configuration-msp-sample.xml
@@ -1,0 +1,19 @@
+<MSPConfig>
+  <Schedules>
+    <sche>
+      <system-id>SCH1</system-id>
+      <name>Filter Schedule</name>
+      <type>equipment</type>
+      <sub-type>pump</sub-type>
+      <enabled>yes</enabled>
+      <device systemId="P1" name="Main Pump" type="Pump" />
+      <parameter name="StartTimeHours" dataType="int">6</parameter>
+      <action type="on">
+        <parameter name="Duration" dataType="int">30</parameter>
+      </action>
+    </sche>
+    <sche system-id="SCH2" name="Chlorinator" type="equipment" sub-type="chlorinator" enabled="no">
+      <parameter name="StartTimeHours" dataType="int">2</parameter>
+    </sche>
+  </Schedules>
+</MSPConfig>


### PR DESCRIPTION
## Summary
- update the schedules container and schedule model to recognise the new `sche` tag alongside legacy schedule elements
- handle lower-case MSP schedule fields and nested elements so devices, parameters and actions populate
- add an MSP sample configuration and unit test that verifies parsing of the new schedule format

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal test *(fails: unable to download parent POM in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9fe7653408323b2b489daa7d271f7