### PR TITLE
Fix DMT device parsing and add nested device test

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/DeviceConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/DeviceConfig.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -23,11 +24,17 @@ public class DeviceConfig {
     @XStreamAlias("System-Id")
     private @Nullable String systemIdElement;
 
+    @XStreamAlias("Device-System-Id")
+    private @Nullable String deviceSystemIdElement;
+
     @XStreamAsAttribute
     private @Nullable String name;
 
     @XStreamAlias("Name")
     private @Nullable String nameElement;
+
+    @XStreamAlias("Device-Name")
+    private @Nullable String deviceNameElement;
 
     @XStreamAsAttribute
     private @Nullable String type;
@@ -35,11 +42,17 @@ public class DeviceConfig {
     @XStreamAlias("Type")
     private @Nullable String typeElement;
 
+    @XStreamAlias("Device-Type")
+    private @Nullable String deviceTypeElement;
+
     @XStreamAsAttribute
     private @Nullable String subType;
 
     @XStreamAlias("Sub-Type")
     private @Nullable String subTypeElement;
+
+    @XStreamAlias("Device-Sub-Type")
+    private @Nullable String deviceSubTypeElement;
 
     @XStreamAsAttribute
     @XStreamAlias("parentSystemId")
@@ -48,30 +61,92 @@ public class DeviceConfig {
     @XStreamAlias("Parent-System-Id")
     private @Nullable String parentSystemIdElement;
 
+    @XStreamAlias("Device-Parent-System-Id")
+    private @Nullable String deviceParentSystemIdElement;
+
+    @XStreamAlias("Node-ID")
+    private @Nullable String nodeIdElement;
+
+    @XStreamAlias("Devices")
+    private @Nullable DeviceList devicesElement;
+
     @XStreamImplicit(itemFieldName = "Parameter")
     private final List<ParameterConfig> parameters = new ArrayList<>();
 
     public @Nullable String getSystemId() {
-        return systemId != null ? systemId : systemIdElement;
+        if (deviceSystemIdElement != null) {
+            return deviceSystemIdElement;
+        }
+        if (systemIdElement != null) {
+            return systemIdElement;
+        }
+        return systemId;
     }
 
     public @Nullable String getName() {
-        return name != null ? name : nameElement;
+        if (deviceNameElement != null) {
+            return deviceNameElement;
+        }
+        if (nameElement != null) {
+            return nameElement;
+        }
+        return name;
     }
 
     public @Nullable String getType() {
-        return type != null ? type : typeElement;
+        if (deviceTypeElement != null) {
+            return deviceTypeElement;
+        }
+        if (typeElement != null) {
+            return typeElement;
+        }
+        return type;
     }
 
     public @Nullable String getSubType() {
-        return subType != null ? subType : subTypeElement;
+        if (deviceSubTypeElement != null) {
+            return deviceSubTypeElement;
+        }
+        if (subTypeElement != null) {
+            return subTypeElement;
+        }
+        return subType;
     }
 
     public @Nullable String getParentSystemId() {
-        return parentSystemId != null ? parentSystemId : parentSystemIdElement;
+        if (deviceParentSystemIdElement != null) {
+            return deviceParentSystemIdElement;
+        }
+        if (parentSystemIdElement != null) {
+            return parentSystemIdElement;
+        }
+        return parentSystemId;
+    }
+
+    public @Nullable String getNodeId() {
+        return nodeIdElement;
+    }
+
+    public List<DeviceConfig> getChildDevices() {
+        DeviceList list = devicesElement;
+        if (list == null) {
+            return Collections.emptyList();
+        }
+        return list.getDevices();
     }
 
     public List<ParameterConfig> getParameters() {
         return parameters;
+    }
+
+    @XStreamAlias("Devices")
+    @NonNullByDefault
+    private static class DeviceList {
+        @XStreamImplicit(itemFieldName = "Device")
+        private final List<DeviceConfig> devices = new ArrayList<>();
+
+        public List<DeviceConfig> getDevices() {
+            return devices;
+        }
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -312,6 +313,33 @@ public class ConfigParserTest {
         assertEquals("StartTimeHours", secondSchedule.getParameters().get(0).getName());
         assertEquals("2", secondSchedule.getParameters().get(0).getValue());
         assertEquals(0, secondSchedule.getActions().size());
+    }
+
+    @Test
+    public void testParseDmtNestedDevices() throws IOException {
+        MspConfig config = parseConfigurationResource("request-dmt-nested-sample.xml");
+
+        List<DeviceConfig> devices = config.getDmt().getDevices();
+        assertEquals(1, devices.size());
+
+        DeviceConfig parentDevice = devices.get(0);
+        assertEquals("DEV-PARENT", parentDevice.getSystemId());
+        assertEquals("Water Feature Pump", parentDevice.getName());
+        assertEquals("PMP_WATER_FEATURE", parentDevice.getType());
+        assertEquals("PMP_FEATURE", parentDevice.getSubType());
+        assertEquals("BY1", parentDevice.getParentSystemId());
+        assertEquals("NODE-001", parentDevice.getNodeId());
+
+        List<DeviceConfig> childDevices = parentDevice.getChildDevices();
+        assertEquals(1, childDevices.size());
+
+        DeviceConfig childDevice = childDevices.get(0);
+        assertEquals("DEV-CHILD", childDevice.getSystemId());
+        assertEquals("Waterfall Light", childDevice.getName());
+        assertEquals("LIGHT_COLOR_LOGIC", childDevice.getType());
+        assertEquals("LIGHT_FEATURE", childDevice.getSubType());
+        assertEquals("DEV-PARENT", childDevice.getParentSystemId());
+        assertEquals("NODE-002", childDevice.getNodeId());
     }
 
     private static MspConfig parseSampleConfiguration() throws IOException {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/resources/org/openhab/binding/haywardomnilogiclocal/internal/config/request-dmt-nested-sample.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/resources/org/openhab/binding/haywardomnilogiclocal/internal/config/request-dmt-nested-sample.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MSPConfig>
+  <DMT>
+    <Device>
+      <Device-System-Id>DEV-PARENT</Device-System-Id>
+      <Device-Name>Water Feature Pump</Device-Name>
+      <Device-Type>PMP_WATER_FEATURE</Device-Type>
+      <Device-Sub-Type>PMP_FEATURE</Device-Sub-Type>
+      <Device-Parent-System-Id>BY1</Device-Parent-System-Id>
+      <Node-ID>NODE-001</Node-ID>
+      <Devices>
+        <Device>
+          <Device-System-Id>DEV-CHILD</Device-System-Id>
+          <Device-Name>Waterfall Light</Device-Name>
+          <Device-Type>LIGHT_COLOR_LOGIC</Device-Type>
+          <Device-Sub-Type>LIGHT_FEATURE</Device-Sub-Type>
+          <Device-Parent-System-Id>DEV-PARENT</Device-Parent-System-Id>
+          <Node-ID>NODE-002</Node-ID>
+        </Device>
+      </Devices>
+    </Device>
+  </DMT>
+</MSPConfig>


### PR DESCRIPTION
## Summary
- map DeviceConfig fields to DMT-specific XML elements, including Device-Name and Node-ID
- expose nested Devices blocks so child Device entries are retained during parsing
- add a dedicated DMT sample and parser test covering top-level and nested device metadata

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal test` *(fails: Maven cannot resolve parent POM without internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca00721af08323a944affcec00c828