### PR TITLE
Adapt MSP action payload parsing

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfig.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfig.java
@@ -1,7 +1,10 @@
 package org.openhab.binding.haywardomnilogiclocal.internal.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -9,16 +12,19 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Representation of an Action element.
  */
 @NonNullByDefault
 @XStreamAlias("Action")
-@XStreamConverter(value = ToAttributedValueConverter.class, strings = "type")
+@XStreamConverter(ActionConfigConverter.class)
 public class ActionConfig {
-    private @Nullable String type;
+    private @Nullable String legacyType;
+
+    private @Nullable String actionFunction;
+
+    private final Map<Integer, String> actionData = new TreeMap<>();
 
     @XStreamImplicit(itemFieldName = "Device")
     private final List<DeviceConfig> devices = new ArrayList<>();
@@ -29,8 +35,65 @@ public class ActionConfig {
     @XStreamImplicit(itemFieldName = "Operation")
     private final List<OperationConfig> operations = new ArrayList<>();
 
+    void setLegacyType(@Nullable String legacyType) {
+        String trimmed = trimToNull(legacyType);
+        if (trimmed != null) {
+            this.legacyType = trimmed;
+        }
+    }
+
+    void setActionFunction(@Nullable String actionFunction) {
+        String trimmed = trimToNull(actionFunction);
+        if (trimmed != null) {
+            this.actionFunction = trimmed;
+        }
+    }
+
+    void addActionData(int index, @Nullable String value) {
+        if (index <= 0) {
+            return;
+        }
+
+        String trimmed = trimToNull(value);
+        if (trimmed != null) {
+            actionData.put(index, trimmed);
+        }
+    }
+
+    void addDevice(DeviceConfig device) {
+        devices.add(device);
+    }
+
+    void addParameter(ParameterConfig parameter) {
+        parameters.add(parameter);
+    }
+
+    void addOperation(OperationConfig operation) {
+        operations.add(operation);
+    }
+
     public @Nullable String getType() {
-        return type;
+        return getActionFunction();
+    }
+
+    public @Nullable String getActionFunction() {
+        if (actionFunction != null) {
+            return actionFunction;
+        }
+
+        return legacyType;
+    }
+
+    public Map<Integer, String> getActionDataByIndex() {
+        return Collections.unmodifiableMap(actionData);
+    }
+
+    public List<String> getActionData() {
+        return Collections.unmodifiableList(new ArrayList<>(actionData.values()));
+    }
+
+    public @Nullable String getActionDataValue(int index) {
+        return actionData.get(index);
     }
 
     public List<DeviceConfig> getDevices() {
@@ -43,5 +106,14 @@ public class ActionConfig {
 
     public List<OperationConfig> getOperations() {
         return operations;
+    }
+
+    private static @Nullable String trimToNull(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverter.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverter.java
@@ -1,0 +1,77 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * Custom XStream converter to deserialize {@link ActionConfig} elements that contain MSP action payloads.
+ */
+@NonNullByDefault
+public class ActionConfigConverter implements Converter {
+
+    private static final String NODE_ACTION_FUNCTION = "Action-Function";
+    private static final String NODE_ACTION_DATA_PREFIX = "Action-Data";
+    private static final String NODE_DEVICE = "Device";
+    private static final String NODE_OPERATION = "Operation";
+    private static final String NODE_PARAMETER = "Parameter";
+
+    @Override
+    public boolean canConvert(Class<?> type) {
+        return ActionConfig.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+        throw new UnsupportedOperationException("ActionConfigConverter only supports unmarshalling");
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        ActionConfig action = new ActionConfig();
+
+        action.setLegacyType(reader.getValue());
+
+        while (reader.hasMoreChildren()) {
+            reader.moveDown();
+            String nodeName = reader.getNodeName();
+            switch (nodeName) {
+                case NODE_ACTION_FUNCTION:
+                    action.setActionFunction(reader.getValue());
+                    break;
+                case NODE_DEVICE:
+                    action.addDevice((DeviceConfig) context.convertAnother(action, DeviceConfig.class));
+                    break;
+                case NODE_OPERATION:
+                    action.addOperation((OperationConfig) context.convertAnother(action, OperationConfig.class));
+                    break;
+                case NODE_PARAMETER:
+                    action.addParameter((ParameterConfig) context.convertAnother(action, ParameterConfig.class));
+                    break;
+                default:
+                    if (nodeName.startsWith(NODE_ACTION_DATA_PREFIX)) {
+                        parseActionData(action, nodeName, reader.getValue());
+                    }
+                    break;
+            }
+            reader.moveUp();
+        }
+
+        return action;
+    }
+
+    private static void parseActionData(ActionConfig action, String nodeName, @Nullable String value) {
+        String indexText = nodeName.substring(NODE_ACTION_DATA_PREFIX.length());
+        try {
+            int index = Integer.parseInt(indexText);
+            action.addActionData(index, value);
+        } catch (NumberFormatException e) {
+            // Ignore unexpected Action-Data node without an integer suffix.
+        }
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverterTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverterTest.java
@@ -1,0 +1,66 @@
+package org.openhab.binding.haywardomnilogiclocal.internal.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ActionConfigConverter} behaviour.
+ */
+public class ActionConfigConverterTest {
+
+    @Test
+    public void testParsesActionFunctionAndDataNodes() {
+        String xml = """
+                <MSPConfig>
+                  <Backyard>
+                    <Pump systemId=\"P1\" name=\"Main\">
+                      <Operation>PEO_SAMPLE
+                        <Action>
+                          <Action-Function>PEA_SAMPLE</Action-Function>
+                          <Action-Data1>Value1</Action-Data1>
+                          <Action-Data2>Value2</Action-Data2>
+                        </Action>
+                      </Operation>
+                    </Pump>
+                  </Backyard>
+                </MSPConfig>
+                """;
+
+        MspConfig config = ConfigParser.parse(xml);
+
+        OperationConfig operation = config.getBackyards().get(0).getPumps().get(0).getOperations().get(0);
+        ActionConfig action = operation.getActions().get(0);
+
+        assertEquals("PEA_SAMPLE", action.getActionFunction());
+        assertEquals(List.of("Value1", "Value2"), action.getActionData());
+        assertEquals("Value1", action.getActionDataValue(1));
+        assertEquals("Value2", action.getActionDataValue(2));
+    }
+
+    @Test
+    public void testFallsBackToLegacyTextualType() {
+        String xml = """
+                <MSPConfig>
+                  <Backyard>
+                    <Pump systemId=\"P1\" name=\"Main\">
+                      <Operation>PEO_SAMPLE
+                        <Action>PEA_LEGACY</Action>
+                      </Operation>
+                    </Pump>
+                  </Backyard>
+                </MSPConfig>
+                """;
+
+        MspConfig config = ConfigParser.parse(xml);
+
+        OperationConfig operation = config.getBackyards().get(0).getPumps().get(0).getOperations().get(0);
+        ActionConfig action = operation.getActions().get(0);
+
+        assertEquals("PEA_LEGACY", action.getActionFunction());
+        assertEquals("PEA_LEGACY", action.getType());
+        assertTrue(action.getActionData().isEmpty());
+    }
+}

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ConfigParserTest.java
@@ -88,7 +88,10 @@ public class ConfigParserTest {
         assertEquals("PEO_FILTER_SAMPLE", filterOperation.getType());
         assertEquals(1, filterOperation.getActions().size());
         ActionConfig filterAction = filterOperation.getActions().get(0);
+        assertEquals("PEA_FILTER_SPEED", filterAction.getActionFunction());
         assertEquals("PEA_FILTER_SPEED", filterAction.getType());
+        assertEquals(List.of("3200", "RPM"), filterAction.getActionData());
+        assertEquals("3200", filterAction.getActionDataValue(1));
         assertEquals(0, filterAction.getDevices().size());
         assertEquals(1, filterAction.getParameters().size());
         assertEquals("Speed", filterAction.getParameters().get(0).getName());
@@ -120,7 +123,8 @@ public class ConfigParserTest {
         assertEquals("PEO_HEATER_FLOW", heaterFlowOp.getType());
         assertEquals(1, heaterFlowOp.getActions().size());
         ActionConfig heaterFlowAction = heaterFlowOp.getActions().get(0);
-        assertEquals("PEA_FLOW", heaterFlowAction.getType());
+        assertEquals("PEA_FLOW", heaterFlowAction.getActionFunction());
+        assertEquals("40", heaterFlowAction.getActionDataValue(1));
         assertEquals(0, heaterFlowAction.getDevices().size());
         assertEquals(1, heaterFlowAction.getParameters().size());
         assertEquals("Flow", heaterFlowAction.getParameters().get(0).getName());
@@ -142,7 +146,8 @@ public class ConfigParserTest {
         assertEquals("PEO_CHLOR_SAMPLE", chlorinatorOp.getType());
         assertEquals(1, chlorinatorOp.getActions().size());
         ActionConfig chlorinatorAction = chlorinatorOp.getActions().get(0);
-        assertEquals("PEA_SET_PERCENT", chlorinatorAction.getType());
+        assertEquals("PEA_SET_PERCENT", chlorinatorAction.getActionFunction());
+        assertEquals(List.of("60"), chlorinatorAction.getActionData());
         assertEquals(0, chlorinatorAction.getDevices().size());
         assertEquals(1, chlorinatorAction.getParameters().size());
         assertEquals("Percent", chlorinatorAction.getParameters().get(0).getName());
@@ -174,7 +179,8 @@ public class ConfigParserTest {
         assertEquals("5", sensorOperationParameter.getValue());
         assertEquals(1, sensorOperation.getActions().size());
         ActionConfig sensorAction = sensorOperation.getActions().get(0);
-        assertEquals("PEA_SENSOR_REPORT", sensorAction.getType());
+        assertEquals("PEA_SENSOR_REPORT", sensorAction.getActionFunction());
+        assertEquals("15", sensorAction.getActionDataValue(1));
         assertEquals(0, sensorAction.getDevices().size());
         assertEquals(1, sensorAction.getParameters().size());
         assertEquals("Interval", sensorAction.getParameters().get(0).getName());
@@ -199,7 +205,8 @@ public class ConfigParserTest {
         assertEquals("PEO_PUMP_SAMPLE", pumpOperation.getType());
         assertEquals(1, pumpOperation.getActions().size());
         ActionConfig pumpAction = pumpOperation.getActions().get(0);
-        assertEquals("PEA_SET_SPEED", pumpAction.getType());
+        assertEquals("PEA_SET_SPEED", pumpAction.getActionFunction());
+        assertEquals("3100", pumpAction.getActionDataValue(1));
         assertEquals(0, pumpAction.getDevices().size());
         assertEquals(1, pumpAction.getParameters().size());
         assertEquals("Speed", pumpAction.getParameters().get(0).getName());
@@ -215,7 +222,8 @@ public class ConfigParserTest {
         assertEquals("PEO_PUMP_CHILD", nestedPumpOperation.getType());
         assertEquals(1, nestedPumpOperation.getActions().size());
         ActionConfig nestedPumpAction = nestedPumpOperation.getActions().get(0);
-        assertEquals("PEA_CHILD_SPEED", nestedPumpAction.getType());
+        assertEquals("PEA_CHILD_SPEED", nestedPumpAction.getActionFunction());
+        assertEquals("2800", nestedPumpAction.getActionDataValue(1));
         assertEquals(1, nestedPumpAction.getParameters().size());
         assertEquals("Speed", nestedPumpAction.getParameters().get(0).getName());
         assertEquals("2800", nestedPumpAction.getParameters().get(0).getValue());

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/resources/org/openhab/binding/haywardomnilogiclocal/internal/config/request-configuration-sample.xml
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/resources/org/openhab/binding/haywardomnilogiclocal/internal/config/request-configuration-sample.xml
@@ -68,7 +68,10 @@
           <Vsp-High-Pump-Speed>100</Vsp-High-Pump-Speed>
           <Vsp-Custom-Pump-Speed>80</Vsp-Custom-Pump-Speed>
         <Operation>PEO_FILTER_SAMPLE
-          <Action>PEA_FILTER_SPEED
+          <Action>
+            <Action-Function>PEA_FILTER_SPEED</Action-Function>
+            <Action-Data1>3200</Action-Data1>
+            <Action-Data2>RPM</Action-Data2>
             <Parameter name="Speed" dataType="int">3200</Parameter>
           </Action>
         </Operation>
@@ -91,7 +94,9 @@
           </Heater-Equipment>
         </Operation>
         <Operation>PEO_HEATER_FLOW
-          <Action>PEA_FLOW
+          <Action>
+            <Action-Function>PEA_FLOW</Action-Function>
+            <Action-Data1>40</Action-Data1>
             <Parameter name="Flow" dataType="int">40</Parameter>
           </Action>
         </Operation>
@@ -104,7 +109,9 @@
         <Cell-Type>CELL_TYPE_T15</Cell-Type>
         <ORP-Timeout>86400</ORP-Timeout>
         <Operation>PEO_CHLOR_SAMPLE
-          <Action>PEA_SET_PERCENT
+          <Action>
+            <Action-Function>PEA_SET_PERCENT</Action-Function>
+            <Action-Data1>60</Action-Data1>
             <Parameter name="Percent" dataType="int">60</Parameter>
           </Action>
         </Operation>
@@ -124,7 +131,9 @@
         <Units>UNITS_FAHRENHEIT</Units>
         <Operation>PEO_SENSOR_SAMPLE
           <Parameter name="SampleRate" dataType="int">5</Parameter>
-          <Action>PEA_SENSOR_REPORT
+          <Action>
+            <Action-Function>PEA_SENSOR_REPORT</Action-Function>
+            <Action-Data1>15</Action-Data1>
             <Parameter name="Interval" dataType="int">15</Parameter>
           </Action>
         </Operation>
@@ -142,14 +151,18 @@
       <Vsp-High-Pump-Speed>100</Vsp-High-Pump-Speed>
       <Vsp-Low-Pump-Speed>30</Vsp-Low-Pump-Speed>
       <Operation>PEO_PUMP_SAMPLE
-        <Action>PEA_SET_SPEED
+        <Action>
+          <Action-Function>PEA_SET_SPEED</Action-Function>
+          <Action-Data1>3100</Action-Data1>
           <Parameter name="Speed" dataType="int">3100</Parameter>
           <Operation>PEO_ACTION_CHILD
             <Parameter name="ChildParam" dataType="int">1</Parameter>
           </Operation>
         </Action>
         <Operation>PEO_PUMP_CHILD
-          <Action>PEA_CHILD_SPEED
+          <Action>
+            <Action-Function>PEA_CHILD_SPEED</Action-Function>
+            <Action-Data1>2800</Action-Data1>
             <Parameter name="Speed" dataType="int">2800</Parameter>
           </Action>
         </Operation>


### PR DESCRIPTION
## Summary
- add a custom XStream converter so ActionConfig captures MSP action functions and indexed data fields
- update the sample configuration and parser test expectations to cover the new action payload structure
- add focused converter tests, including coverage for legacy text-only actions

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal test *(fails: unable to resolve parent POM without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cb16cd7208832394bacb1487854374