### PR TITLE
Fix nullable overrides for ActionConfigConverter

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverter.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverter.java
@@ -22,17 +22,17 @@ public class ActionConfigConverter implements Converter {
     private static final String NODE_PARAMETER = "Parameter";
 
     @Override
-    public boolean canConvert(Class<?> type) {
-        return ActionConfig.class.isAssignableFrom(type);
+    public boolean canConvert(@Nullable Class<?> type) {
+        return type != null && ActionConfig.class.isAssignableFrom(type);
     }
 
     @Override
-    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+    public void marshal(@Nullable Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
         throw new UnsupportedOperationException("ActionConfigConverter only supports unmarshalling");
     }
 
     @Override
-    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+    public @Nullable Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
         ActionConfig action = new ActionConfig();
 
         action.setLegacyType(reader.getValue());


### PR DESCRIPTION
## Summary
- mirror the nullable contract from XStream's Converter interface in ActionConfigConverter
- guard the canConvert method against null types before checking assignability

## Testing
- `mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal -am compile` *(fails: requires parent POM from remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2020001883238d7c0f67559ce242