### PR TITLE
Fix ActionConfigConverter canConvert signature

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverter.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/config/ActionConfigConverter.java
@@ -22,7 +22,8 @@ public class ActionConfigConverter implements Converter {
     private static final String NODE_PARAMETER = "Parameter";
 
     @Override
-    public boolean canConvert(@Nullable Class<?> type) {
+    @SuppressWarnings("rawtypes")
+    public boolean canConvert(@Nullable Class type) {
         return type != null && ActionConfig.class.isAssignableFrom(type);
     }
 


### PR DESCRIPTION
## Summary
- adjust the ActionConfigConverter `canConvert` signature to use the raw `Class` parameter expected by XStream

## Testing
- mvn -pl :org.openhab.binding.haywardomnilogiclocal -am compile -DskipTests *(fails: cannot resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3237a2448323814362677a3d2c7c