### PR TITLE
Handle missing pumps during Hayward discovery

### DIFF
--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/main/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryService.java
@@ -15,6 +15,7 @@ package org.openhab.binding.haywardomnilogiclocal.internal.discovery;
 import static org.openhab.binding.haywardomnilogiclocal.internal.HaywardBindingConstants.THING_TYPES_UIDS;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -203,16 +204,19 @@ public class HaywardDiscoveryService extends AbstractThingHandlerDiscoveryServic
                 }
             }
 
-            for (PumpConfig pump : backyard.getPumps()) {
-                Map<String, Object> pumpProps = new HashMap<>();
-                pumpProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
-                String pumpId = pump.getSystemId();
-                putIfNotNull(pumpProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, pumpId);
-                String name = pump.getName() != null ? pump.getName() : pumpId;
-                if (name == null) {
-                    name = "Pump";
+            List<PumpConfig> pumps = backyard.getPumps();
+            if (pumps != null) {
+                for (PumpConfig pump : pumps) {
+                    Map<String, Object> pumpProps = new HashMap<>();
+                    pumpProps.put(HaywardBindingConstants.PROPERTY_TYPE, HaywardTypeToRequest.PUMP);
+                    String pumpId = pump.getSystemId();
+                    putIfNotNull(pumpProps, HaywardBindingConstants.PROPERTY_SYSTEM_ID, pumpId);
+                    String name = pump.getName() != null ? pump.getName() : pumpId;
+                    if (name == null) {
+                        name = "Pump";
+                    }
+                    onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_PUMP, name, pumpProps);
                 }
-                onDeviceDiscovered(HaywardBindingConstants.THING_TYPE_PUMP, name, pumpProps);
             }
 
             for (RelayConfig relay : backyard.getRelays()) {

--- a/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryServiceTest.java
+++ b/bundles/org.openhab.binding.haywardomnilogiclocal/src/test/java/org/openhab/binding/haywardomnilogiclocal/internal/discovery/HaywardDiscoveryServiceTest.java
@@ -107,6 +107,30 @@ public class HaywardDiscoveryServiceTest {
     }
 
     @Test
+    public void mspConfigDiscoverySkipsMissingPumps() {
+        String xml = "" +
+                "<MSPConfig>" +
+                "  <System systemId='SYS'/>" +
+                "  <Backyard systemId='BY'>" +
+                "    <Sensor systemId='S1' name='Air' type='SENSOR_AIR_TEMP' units='UNITS_FAHRENHEIT'/>" +
+                "    <BodyOfWater systemId='BOW1' name='Pool'>" +
+                "      <Filter systemId='F1' pumpId='P1'/>" +
+                "    </BodyOfWater>" +
+                "  </Backyard>" +
+                "</MSPConfig>";
+
+        TestDiscoveryService service = new TestDiscoveryService();
+        service.mspConfigDiscovery(xml);
+
+        assertEquals(0, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_PUMP)).count());
+        assertEquals(1,
+                service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_BACKYARD)).count());
+        assertEquals(1, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_BOW)).count());
+        assertEquals(1, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_FILTER)).count());
+        assertEquals(1, service.types.stream().filter(t -> t.equals(HaywardBindingConstants.THING_TYPE_SENSOR)).count());
+    }
+
+    @Test
     public void mspConfigDiscoveryIdentifiesValveActuatorRelays() {
         String xml = "" +
                 "<MSPConfig>" +


### PR DESCRIPTION
## Summary
- guard pump discovery when the MSP config omits the backyard pump list
- add a regression test to ensure discovery continues when pumps are absent

## Testing
- mvn -pl bundles/org.openhab.binding.haywardomnilogiclocal test *(fails: Non-resolvable parent POM org.openhab:openhab-super-pom due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb485601c83238b8ec554747cc146